### PR TITLE
fix duplicate onInitialized(false) call in DeployGate.install(...).

### DIFF
--- a/src/com/deploygate/sdk/DeployGate.java
+++ b/src/com/deploygate/sdk/DeployGate.java
@@ -215,10 +215,7 @@ public class DeployGate {
             mCallbacks.add(callback);
 
         mInitializedLatch = new CountDownLatch(1);
-        if (!initService(true)) {
-            if (callback != null)
-                callback.onInitialized(false);
-        }
+        initService(true);
     }
 
     private boolean initService(boolean isBoot) {


### PR DESCRIPTION
If deploy gate is not avaiable on install, onInitialized(false) is called twice.
It may be an intentional behavior because first call of onInitialized(false) happens before returning from DeplayGate.install(...).
If so, please reject this PR.