### PR TITLE
Stop sending custom exceptions with serializing them

### DIFF
--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -66,6 +66,8 @@ public class DeployGate {
             "234eff4a1600a7aa78bf68adfbb15786e886ae1a", // jenkins debug
     };
 
+    private static final int SERIALIZED_EXCEPTION_SUPPORT_CLIENT_VERSION = 42;
+
     private static DeployGate sInstance;
 
     private final Context mApplicationContext;
@@ -902,7 +904,7 @@ public class DeployGate {
         
         Bundle extras = new Bundle();
         try {
-            if (getDeployGateVersionCode() > 41 /* greater than ver 1.7.2 */) {
+            if (getDeployGateVersionCode() >= SERIALIZED_EXCEPTION_SUPPORT_CLIENT_VERSION) {
                 Throwable rootCause = getRootCause(ex);
                 String msg = rootCause.getMessage();
                 extras.putString(DeployGateEvent.EXTRA_EXCEPTION_ROOT_CAUSE_CLASSNAME, rootCause.getClass().getName());

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -902,7 +902,7 @@ public class DeployGate {
         
         Bundle extras = new Bundle();
         try {
-            if (getDeployGateVersionCode() > 42 /*todo*/) {
+            if (getDeployGateVersionCode() > 41 /* greater than ver 1.7.2 */) {
                 Throwable rootCause = getRootCause(ex);
                 String msg = rootCause.getMessage();
                 extras.putString(DeployGateEvent.EXTRA_EXCEPTION_ROOT_CAUSE_CLASSNAME, rootCause.getClass().getName());

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -926,13 +926,9 @@ public class DeployGate {
         Throwable cause = ex;
         LinkedList<Throwable> throwables = new LinkedList<>();
 
-        while (true) {
-            if (cause != null && !throwables.contains(cause)) {
-                throwables.add(cause);
-                cause = cause.getCause();
-            } else {
-                break;
-            }
+        while (cause != null && !throwables.contains(cause)) {
+            throwables.add(cause);
+            cause = cause.getCause();
         }
 
         return throwables.getLast();

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -924,22 +924,18 @@ public class DeployGate {
     /* non-null */
     private static Throwable getRootCause(/* non-null */ Throwable ex) {
         Throwable cause = ex;
-
-        List<Throwable> throwables = new ArrayList<>(Collections.singleton(cause));
-
-        Throwable rootCause = cause;
+        LinkedList<Throwable> throwables = new LinkedList<>();
 
         while (true) {
-            cause = cause.getCause();
-
             if (cause != null && !throwables.contains(cause)) {
-                throwables.add(rootCause = cause);
+                throwables.add(cause);
+                cause = cause.getCause();
             } else {
                 break;
             }
         }
 
-        return rootCause;
+        return throwables.getLast();
     }
 
     void sendLog(String type, String body) {

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -902,10 +902,10 @@ public class DeployGate {
         
         Bundle extras = new Bundle();
         try {
-            if (getDeployGateVersionCode() > 41 /*todo*/) {
+            if (getDeployGateVersionCode() > 42 /*todo*/) {
                 Throwable rootCause = getRootCause(ex);
                 String msg = rootCause.getMessage();
-                extras.putString(DeployGateEvent.EXTRA_EXCEPTION_ROOT_CAUSE_CLASSNAME, ex.getClass().getName());
+                extras.putString(DeployGateEvent.EXTRA_EXCEPTION_ROOT_CAUSE_CLASSNAME, rootCause.getClass().getName());
                 extras.putString(DeployGateEvent.EXTRA_EXCEPTION_ROOT_CAUSE_MESSAGE, msg != null ? msg : "");
                 extras.putString(DeployGateEvent.EXTRA_EXCEPTION_STACKTRACES, Log.getStackTraceString(ex));
             } else {

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -921,10 +921,14 @@ public class DeployGate {
 
     /* non-null */
     private static Throwable getRootCause(/* non-null */ Throwable ex) {
-        List<Throwable> throwables = new ArrayList<>(Collections.singleton(ex));
-        Throwable rootCause = ex;
+        Throwable cause = ex;
+
+        List<Throwable> throwables = new ArrayList<>(Collections.singleton(cause));
+
+        Throwable rootCause = cause;
+
         while (true) {
-            Throwable cause = ex.getCause();
+            cause = cause.getCause();
 
             if (cause != null && !throwables.contains(cause)) {
                 throwables.add(rootCause = cause);

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -34,7 +34,7 @@ public interface DeployGateEvent {
     /**
      * this key shouldn't be used
      *
-     * {@see com.deploygate.sdk.DeployGate#SERIALIZED_EXCEPTION_SUPPORT_CLIENT_VERSION}
+     * @see com.deploygate.sdk.DeployGate#SERIALIZED_EXCEPTION_SUPPORT_CLIENT_VERSION
      */
     @Deprecated
     public static final String EXTRA_EXCEPTION = "exception";

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -31,6 +31,9 @@ public interface DeployGateEvent {
     public static final String EXTRA_LOG = "log";
     public static final String EXTRA_LOG_TYPE = "logType";
     public static final String EXTRA_EXCEPTION = "exception";
+    public static final String EXTRA_EXCEPTION_ROOT_CAUSE_CLASSNAME = "exceptionRootCauseClassName";
+    public static final String EXTRA_EXCEPTION_ROOT_CAUSE_MESSAGE = "exceptionRootCauseMessage";
+    public static final String EXTRA_EXCEPTION_STACKTRACES = "exceptionStackTraces";
     public static final String EXTRA_CURRENT_REVISION = "currentRevision";
     public static final String EXTRA_CURRENT_DISTRIBUTION_ID = "currentDistributionId";
     public static final String EXTRA_CURRENT_DISTRIBUTION_TITLE = "currentDistributionTitle";

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -30,6 +30,13 @@ public interface DeployGateEvent {
     public static final String EXTRA_IS_BOOT = "isBoot";
     public static final String EXTRA_LOG = "log";
     public static final String EXTRA_LOG_TYPE = "logType";
+
+    /**
+     * this key shouldn't be used
+     *
+     * {@see com.deploygate.sdk.DeployGate#SERIALIZED_EXCEPTION_SUPPORT_CLIENT_VERSION}
+     */
+    @Deprecated
     public static final String EXTRA_EXCEPTION = "exception";
     public static final String EXTRA_EXCEPTION_ROOT_CAUSE_CLASSNAME = "exceptionRootCauseClassName";
     public static final String EXTRA_EXCEPTION_ROOT_CAUSE_MESSAGE = "exceptionRootCauseMessage";


### PR DESCRIPTION
The current DeployGate client app cannot report custom exceptions due to missing ClassLoader.

So sdk should change a way to report crashes

*Old method*
Just serialize a given throwable into an extra and emit it.

*New method*
Extract a root cause message and stacktraces. And then, store them to an extra and emit it.

## Evidences

### For known exceptions

*New method*

<img width="300" src="https://user-images.githubusercontent.com/4340693/36462685-308b2160-1708-11e8-94e2-20cce3002fae.jpg">

```
java.lang.IllegalStateException: Could not execute method for android:onClick
	at android.view.View$DeclaredOnClickListener.onClick(View.java:4700)
	at android.view.View.performClick(View.java:5612)
	at android.view.View$PerformClick.run(View.java:22288)
	at android.os.Handler.handleCallback(Handler.java:751)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:154)
	at android.app.ActivityThread.main(ActivityThread.java:6123)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:867)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:757)
Caused by: java.lang.reflect.InvocationTargetException
	at java.lang.reflect.Method.invoke(Native Method)
	at android.view.View$DeclaredOnClickListener.onClick(View.java:4695)
	... 9 more
Caused by: java.lang.IllegalStateException: ;(
	at com.deploygate.deploygatedevtool.MainActivity.onCrashMeClickKnown(MainActivity.java:89)
	... 11 more
```

*Old method*

<img width="300" src="https://user-images.githubusercontent.com/4340693/36462687-33a0c760-1708-11e8-8945-8dbede84f9e0.jpg">

```
java.lang.IllegalStateException: Could not execute method for android:onClick
	at android.view.View$DeclaredOnClickListener.onClick(View.java:4700)
	at android.view.View.performClick(View.java:5612)
	at android.view.View$PerformClick.run(View.java:22288)
	at android.os.Handler.handleCallback(Handler.java:751)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:154)
	at android.app.ActivityThread.main(ActivityThread.java:6123)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:867)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:757)
Caused by: java.lang.reflect.InvocationTargetException
	at java.lang.reflect.Method.invoke(Native Method)
	at android.view.View$DeclaredOnClickListener.onClick(View.java:4695)
	... 9 more
Caused by: java.lang.IllegalStateException: ;(
	at com.deploygate.deploygatedevtool.MainActivity.onCrashMeClickKnown(MainActivity.java:89)
	... 11 more
```

### For custom exceptions

*New method*

<img width="300" src="https://user-images.githubusercontent.com/4340693/36462708-55d1a70a-1708-11e8-98b0-25a67e48f599.jpg">

```
java.lang.IllegalStateException: Could not execute method for android:onClick
	at android.view.View$DeclaredOnClickListener.onClick(View.java:4700)
	at android.view.View.performClick(View.java:5612)
	at android.view.View$PerformClick.run(View.java:22288)
	at android.os.Handler.handleCallback(Handler.java:751)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:154)
	at android.app.ActivityThread.main(ActivityThread.java:6123)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:867)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:757)
Caused by: java.lang.reflect.InvocationTargetException
	at java.lang.reflect.Method.invoke(Native Method)
	at android.view.View$DeclaredOnClickListener.onClick(View.java:4695)
	... 9 more
Caused by: com.deploygate.deploygatedevtool.internal.CustomException: Hi! I'm in depth 1 right now! I'm a root
	at com.deploygate.deploygatedevtool.MainActivity.onCrashMeClick(MainActivity.java:84)
	... 11 more
```

*Old method*

None. Crash report was not sent to the server.