### PR TITLE
Fixed generated pom files didn't include license and so on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ local.properties
 # gradle
 build/
 .gradle
-gradle.properties
 
 #idea
 *.iml

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,8 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
 
-        classpath 'com.deploygate:gradle:1.1.4'
+        classpath 'com.deploygate:gradle:2.1.0'
         classpath 'com.novoda:bintray-release:0.9.2'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4' // 1.7.1+ is required for Java 7
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/sdk.build.gradle
+++ b/sdk.build.gradle
@@ -32,3 +32,37 @@ dependencies {
     testImplementation 'androidx.test:rules:1.2.0'
     testImplementation 'com.google.truth:truth:1.0'
 }
+
+def pomConfig = {
+    name project.ext.displayName
+    description project.publish.desc
+    url project.publish.website
+    licenses {
+        license {
+            name "The Apache Software License, Version 2.0"
+            url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            distribution "repo"
+        }
+    }
+    developers {
+        developer {
+            name "DeployGate"
+        }
+    }
+
+    scm {
+        url 'https://github.com/DeployGate/deploygate-android-sdk'
+    }
+}
+
+project.plugins.withType(MavenPublishPlugin) {
+    def publishingExtension = project.extensions.findByType(PublishingExtension)
+
+    publishingExtension.publications.withType(MavenPublication).whenObjectAdded {
+        if (name == "release") {
+            pom.withXml {
+                asNode().children().last() + pomConfig
+            }
+        }
+    }
+}

--- a/sdk.build.gradle
+++ b/sdk.build.gradle
@@ -33,33 +33,33 @@ dependencies {
     testImplementation 'com.google.truth:truth:1.0'
 }
 
-def pomConfig = {
-    name project.ext.displayName
-    description project.publish.desc
-    url project.publish.website
-    licenses {
-        license {
-            name "The Apache Software License, Version 2.0"
-            url "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            distribution "repo"
-        }
-    }
-    developers {
-        developer {
-            name "DeployGate"
-        }
-    }
-
-    scm {
-        url 'https://github.com/DeployGate/deploygate-android-sdk'
-    }
-}
-
 project.plugins.withType(MavenPublishPlugin) {
+    def pomConfig = {
+        name project.ext.displayName
+        description project.publish.desc
+        url project.publish.website
+        licenses {
+            license {
+                name "The Apache Software License, Version 2.0"
+                url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution "repo"
+            }
+        }
+        developers {
+            developer {
+                name "DeployGate"
+            }
+        }
+
+        scm {
+            url 'https://github.com/DeployGate/deploygate-android-sdk'
+        }
+    }
+
     def publishingExtension = project.extensions.findByType(PublishingExtension)
 
     publishingExtension.publications.withType(MavenPublication).whenObjectAdded {
-        if (name == "release") {
+        if (project.publish.publications.contains(name)) {
             pom.withXml {
                 asNode().children().last() + pomConfig
             }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -2,6 +2,10 @@ apply from: '../sdk.build.gradle'
 
 android.defaultConfig.consumerProguardFiles 'deploygate-sdk-proguard-rules.txt'
 
+ext {
+    displayName = "DeployGate SDK"
+}
+
 publish {
     userOrg = 'deploygate'
     repoName = 'maven'

--- a/sdkMock/build.gradle
+++ b/sdkMock/build.gradle
@@ -2,6 +2,10 @@ apply from: '../sdk.build.gradle'
 
 android.sourceSets.test.java.srcDirs += [rootProject.file('sdk/src/test/java')]
 
+ext {
+    displayName = "DeployGate SDK Mock"
+}
+
 publish {
     userOrg = 'deploygate'
     repoName = 'maven'


### PR DESCRIPTION
Fixed #23 

`com.novoda:bintray-release` doesn't append several fields to pom files by design.