### PR TITLE
Support Android 11's PackageVisibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.3'
 
         classpath 'com.deploygate:gradle:2.1.0'
         classpath 'com.novoda:bintray-release:0.9.2'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'deploygate'
 
 android {
-    compileSdkVersion = 28
+    compileSdkVersion = 30
 
     defaultConfig {
         applicationId "com.deploygate.sample"
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 30
     }
 
     buildTypes {

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -6,4 +6,7 @@
             android:name=".DeployGateProvider"
             android:exported="false" />
     </application>
+    <queries>
+        <package android:name="com.deploygate" />
+    </queries>
 </manifest>


### PR DESCRIPTION
As Package Visibility changes, the explicit package element is required to bind the service of DeployGate client app.

This change will build the sample project with Android R so AGP version needs to be upgraded to 3.6.1 or higher.
