### PR TITLE
Added a workaround to generate javadocs with Android Gradle Plugin 3.6.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,9 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.3'
 
-        classpath 'com.deploygate:gradle:2.1.0'
+        classpath 'com.deploygate:gradle:2.2.0'
         classpath 'com.novoda:bintray-release:0.9.2'
     }
 }

--- a/sdk.build.gradle
+++ b/sdk.build.gradle
@@ -66,3 +66,12 @@ project.plugins.withType(MavenPublishPlugin) {
         }
     }
 }
+
+afterEvaluate {
+    android.libraryVariants.configureEach { variant ->
+        tasks.findByName("javadoc${variant.name.capitalize()}").configure {
+            // android classpath is required since AGP 3.6
+            classpath += files(android.getBootClasspath())
+        }
+    }
+}


### PR DESCRIPTION
Close #25 

Android classpath has been excluded from each classpath of variants so we need to add it explicitly.