### PR TITLE
Prepare for 4.3.0 release which supports target sdk version 30

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,8 @@ jobs:
       - slack/notify:
           message: Just released new deploygate-android-sdk on <https://bintray.com/beta/#/deploygate/maven/sdk?tab=overview|Bintray>!
     environment:
-      DRY_RUN_RELEASE: false
+      BINTRAY_DRY_RUN: false
+      BINTRAY_PUBLISH: true
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dependencies {
 
 Then synchronize, build and upload your app to DeployGate. [Gradle DeployGate Plugin](https://github.com/DeployGate/gradle-deploygate-plugin/) will be your help.
 
-> Since 4.0.0, you don't need to add `DeployGate.install(this)` to your `Application#onCreate` except you have multiple processes. It is automatically called when your application process starts.
+> Since 4.0.0, you don't need to add `DeployGate.install(this)` to your `Application#onCreate` except you have multiple processes. It is automatically called when your application process starts through the ContentProvider initialization.
 
 ### For Jetpack App Startup users or those who would like to initialize SDK manually
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 You can integrate DeployGate's realtime remote logging & crash reporting without code modification on your apps in development.
 
-> 4.3.0 alphas and 4.3.0 will require updating Android Studio to the latest patch version of 3.3 or above.
+> 4.3.0 and later require Android Studio whose versions are the latest patch version of 3.3 or above.
 > For the more details, please see https://developer.android.com/studio/releases/gradle-plugin#4.0.1
 
 ## Install
@@ -24,7 +24,7 @@ dependencies {
 
 Then synchronize, build and upload your app to DeployGate. [Gradle DeployGate Plugin](https://github.com/DeployGate/gradle-deploygate-plugin/) will be your help.
 
-Since 4.0.0, you don't need to add `DeployGate.install(this)` to your `Application#onCreate` except you have multiple processes. It is automatically called when your application process starts.
+> Since 4.0.0, you don't need to add `DeployGate.install(this)` to your `Application#onCreate` except you have multiple processes. It is automatically called when your application process starts.
 
 ### For Jetpack App Startup users or those who would like to initialize SDK manually
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 ext {
-    releaseVersion = '4.3.0-alpha01'
+    releaseVersion = '4.3.0'
 }
 
 buildscript {
@@ -9,10 +9,10 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
-        classpath 'com.deploygate:gradle:2.2.0'
-        classpath 'com.novoda:bintray-release:0.9.2'
+        classpath 'com.deploygate:gradle:2.3.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/publishing.build.gradle
+++ b/publishing.build.gradle
@@ -21,8 +21,8 @@ bintray {
 println("bintray dryRun : ${bintray.dryRun}")
 println("bintray publish : ${bintray.publish}")
 
-afterEvaluate {
-    android.libraryVariants.configureEach { variant ->
+android.libraryVariants.configureEach { variant ->
+    if (bintray.publications.contains(variant.name)) {
         project.task("generateJavadocFor${variant.name.capitalize()}Publication", type: Javadoc) {
             source = variant.getJavaCompileProvider().get().source
             classpath = variant.getJavaCompileProvider().get().classpath + files(project.android.getBootClasspath())
@@ -45,7 +45,9 @@ afterEvaluate {
                 "generatePomFileFor${variant.name.capitalize()}Publication"
         )
     }
+}
 
+afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {

--- a/publishing.build.gradle
+++ b/publishing.build.gradle
@@ -1,0 +1,82 @@
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.bintray'
+
+bintray {
+    user = project.getProperties().get("bintrayUser")
+    key = project.getProperties().get("bintrayKey")
+
+    pkg {
+        repo = 'maven'
+        name = project.ext.artifactId
+        userOrg = 'deploygate'
+        licenses = ['Apache-2.0']
+    }
+
+    publications = ['release']
+}
+
+afterEvaluate {
+    android.libraryVariants.configureEach { variant ->
+        project.task("generateJavadocFor${variant.name.capitalize()}Publication", type: Javadoc) {
+            source = variant.getJavaCompileProvider().get().source
+            classpath = variant.getJavaCompileProvider().get().classpath + files(project.android.getBootClasspath())
+            options.linkSource true
+        }
+
+        project.task("generateSourcesJarFor${variant.name.capitalize()}Publication", type: Jar) {
+            archiveClassifier.set('sources')
+            from variant.sourceSets.collect { it.javaDirectories }.flatten()
+        }
+
+        project.task("generateJavadocsJarFor${variant.name.capitalize()}Publication", type: Jar) {
+            archiveClassifier.set('javadoc')
+            from files(tasks.getByName("generateJavadocFor${variant.name.capitalize()}Publication"))
+        }
+
+        project.tasks.findByName("assemble${variant.name.capitalize()}").dependsOn(
+                "generateSourcesJarFor${variant.name.capitalize()}Publication",
+                "generateJavadocsJarFor${variant.name.capitalize()}Publication"
+        )
+    }
+
+    publishing {
+        publications {
+            def pomConfig = {
+                name project.ext.displayName
+                description project.ext.desc
+                url 'https://github.com/DeployGate/deploygate-android-sdk'
+                licenses {
+                    license {
+                        name "The Apache Software License, Version 2.0"
+                        url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                        distribution "repo"
+                    }
+                }
+                developers {
+                    developer {
+                        name "DeployGate"
+                    }
+                }
+
+                scm {
+                    url 'https://github.com/DeployGate/deploygate-android-sdk'
+                }
+            }
+
+            release(MavenPublication) {
+                from components.release
+                artifact generateSourcesJarForReleasePublication
+                artifact generateJavadocsJarForReleasePublication
+
+                groupId = 'com.deploygate'
+                artifactId = project.ext.artifactId
+                version = project.version
+
+                pom.withXml {
+                    asNode().children().last() + pomConfig
+                }
+            }
+        }
+    }
+}
+

--- a/publishing.build.gradle
+++ b/publishing.build.gradle
@@ -13,7 +13,13 @@ bintray {
     }
 
     publications = ['release']
+
+    dryRun = project.getProperties().get("bintrayDryRun") != "false"
+    publish = project.getProperties().get("bintrayPublish") == "true"
 }
+
+println("bintray dryRun : ${bintray.dryRun}")
+println("bintray publish : ${bintray.publish}")
 
 afterEvaluate {
     android.libraryVariants.configureEach { variant ->
@@ -35,34 +41,13 @@ afterEvaluate {
 
         project.tasks.findByName("assemble${variant.name.capitalize()}").dependsOn(
                 "generateSourcesJarFor${variant.name.capitalize()}Publication",
-                "generateJavadocsJarFor${variant.name.capitalize()}Publication"
+                "generateJavadocsJarFor${variant.name.capitalize()}Publication",
+                "generatePomFileFor${variant.name.capitalize()}Publication"
         )
     }
 
     publishing {
         publications {
-            def pomConfig = {
-                name project.ext.displayName
-                description project.ext.desc
-                url 'https://github.com/DeployGate/deploygate-android-sdk'
-                licenses {
-                    license {
-                        name "The Apache Software License, Version 2.0"
-                        url "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                        distribution "repo"
-                    }
-                }
-                developers {
-                    developer {
-                        name "DeployGate"
-                    }
-                }
-
-                scm {
-                    url 'https://github.com/DeployGate/deploygate-android-sdk'
-                }
-            }
-
             release(MavenPublication) {
                 from components.release
                 artifact generateSourcesJarForReleasePublication
@@ -72,8 +57,25 @@ afterEvaluate {
                 artifactId = project.ext.artifactId
                 version = project.version
 
-                pom.withXml {
-                    asNode().children().last() + pomConfig
+                pom {
+                    name = project.ext.displayName
+                    description = project.ext.desc
+                    url = 'https://github.com/DeployGate/deploygate-android-sdk'
+                    licenses {
+                        license {
+                            name =  "The Apache Software License, Version 2.0"
+                            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                            distribution = "repo"
+                        }
+                    }
+                    developers {
+                        developer {
+                            name = "DeployGate"
+                        }
+                    }
+                    scm {
+                        url = 'https://github.com/DeployGate/deploygate-android-sdk'
+                    }
                 }
             }
         }

--- a/release.sh
+++ b/release.sh
@@ -5,4 +5,8 @@ set -euo pipefail
 ./gradlew clean \
     sdk:assembleRelease sdkMock:assembleRelease \
     sdk:bintrayUpload sdkMock:bintrayUpload \
-    -PbintrayUser=$BINTRAY_USER -PbintrayKey=$BINTRAY_KEY -PdryRun=${DRY_RUN_RELEASE:-true} --stacktrace
+    -PbintrayUser=$BINTRAY_USER \
+    -PbintrayKey=$BINTRAY_KEY \
+    -PbintryDryRun=${BINTRAY_DRY_RUN:-true} \
+    -PbintryPublish=${BINTRAY_PUBLISH:-false} \
+    --stacktrace

--- a/sdk.build.gradle
+++ b/sdk.build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.novoda.bintray-release'
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.bintray'
 
 version = rootProject.ext.releaseVersion
 
@@ -31,47 +32,4 @@ dependencies {
 
     testImplementation 'androidx.test:rules:1.2.0'
     testImplementation 'com.google.truth:truth:1.0'
-}
-
-project.plugins.withType(MavenPublishPlugin) {
-    def pomConfig = {
-        name project.ext.displayName
-        description project.publish.desc
-        url project.publish.website
-        licenses {
-            license {
-                name "The Apache Software License, Version 2.0"
-                url "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                distribution "repo"
-            }
-        }
-        developers {
-            developer {
-                name "DeployGate"
-            }
-        }
-
-        scm {
-            url 'https://github.com/DeployGate/deploygate-android-sdk'
-        }
-    }
-
-    def publishingExtension = project.extensions.findByType(PublishingExtension)
-
-    publishingExtension.publications.withType(MavenPublication).whenObjectAdded {
-        if (project.publish.publications.contains(name)) {
-            pom.withXml {
-                asNode().children().last() + pomConfig
-            }
-        }
-    }
-}
-
-afterEvaluate {
-    android.libraryVariants.configureEach { variant ->
-        tasks.findByName("javadoc${variant.name.capitalize()}").configure {
-            // android classpath is required since AGP 3.6
-            classpath += files(android.getBootClasspath())
-        }
-    }
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,20 +1,11 @@
-apply from: '../sdk.build.gradle'
+apply from: rootProject.file('sdk.build.gradle')
 
 android.defaultConfig.consumerProguardFiles 'deploygate-sdk-proguard-rules.txt'
 
 ext {
     displayName = "DeployGate SDK"
-}
-
-publish {
-    userOrg = 'deploygate'
-    repoName = 'maven'
-    groupId = 'com.deploygate'
     artifactId = 'sdk'
-    publishVersion = project.version
-    licences = ['Apache-2.0']
     desc = 'DeployGate SDK for Android'
-    website = 'https://github.com/DeployGate/deploygate-android-sdk'
-
-    publications = ['release']
 }
+
+apply from: rootProject.file('publishing.build.gradle')

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -360,7 +360,7 @@ public class DeployGate {
      * Install DeployGate on your application instance. Call this method inside
      * of your {@link Application#onCreate()} once.
      * <p>
-     * On a release build, which has <tt>android:isDebuggable</tt> set false on
+     * On a release build, which has <code>android:isDebuggable</code> set false on
      * AndroidManifest.xml, this function will do nothing. If you want to enable
      * DeployGate on a release build, consider using
      * {@link #install(Application, String, DeployGateCallback, boolean)}
@@ -385,7 +385,7 @@ public class DeployGate {
      * Install DeployGate on your application instance. Call this method inside
      * of your {@link Application#onCreate()} once.
      * <p>
-     * On a release build, which has <tt>android:isDebuggable</tt> set false on
+     * On a release build, which has <code>android:isDebuggable</code> set false on
      * AndroidManifest.xml, this function will do nothing. If you want to enable
      * DeployGate on a release build, consider using
      * {@link #install(Application, String, DeployGateCallback, boolean)}
@@ -406,7 +406,7 @@ public class DeployGate {
      * listener. Call this method inside of your {@link Application#onCreate()}
      * once.
      * <p>
-     * On a release build, which has <tt>android:isDebuggable</tt> set false on
+     * On a release build, which has <code>android:isDebuggable</code> set false on
      * AndroidManifest.xml, this function will do nothing. If you want to enable
      * DeployGate on a release build, consider using
      * {@link #install(Application, String, DeployGateCallback, boolean)}
@@ -454,7 +454,7 @@ public class DeployGate {
      * listener. Call this method inside of your {@link Application#onCreate()}
      * once.
      * <p>
-     * On a release build, which has <tt>android:isDebuggable</tt> set false on
+     * On a release build, which has <code>android:isDebuggable</code> set false on
      * AndroidManifest.xml, this function will do nothing. If you want to enable
      * DeployGate on a release build, consider using
      * {@link #install(Application, String, DeployGateCallback, boolean)}
@@ -526,7 +526,7 @@ public class DeployGate {
      * the DeployGate service. Nothing happens if this called before
      * {@link #install(Application)} or when refreshing is already in progress.
      * Note that after calling this, {@link #isInitialized()} will changed to
-     * false immediately and any call to <tt>is*()</tt> will be blocked until
+     * false immediately and any call to <code>is*()</code> will be blocked until
      * refreshing get finished.
      * 
      * @since r1

--- a/sdkMock/build.gradle
+++ b/sdkMock/build.gradle
@@ -1,20 +1,11 @@
-apply from: '../sdk.build.gradle'
+apply from: rootProject.file('sdk.build.gradle')
 
 android.sourceSets.test.java.srcDirs += [rootProject.file('sdk/src/test/java')]
 
 ext {
     displayName = "DeployGate SDK Mock"
-}
-
-publish {
-    userOrg = 'deploygate'
-    repoName = 'maven'
-    groupId = 'com.deploygate'
     artifactId = 'sdk-mock'
-    publishVersion = project.version
-    licences = ['Apache-2.0']
     desc = 'Mocked dummy DeployGate SDK for Android to reduce footprint of your release version app without code modification'
-    website = 'https://github.com/DeployGate/deploygate-android-sdk'
-
-    publications = ['release']
 }
+
+apply from: rootProject.file('publishing.build.gradle')


### PR DESCRIPTION
No code changes.

- Tweaked README
- Bumped up version
- Upgraded AGP. 
    - Rewriting the maven publishing configuration is required because Gradle 6.0, which the new AGP depends on, breaks https://github.com/novoda/bintray-release compatibility but they haven't merged the fixing.