### PR TITLE
Measure and send buffered-time in on-memory buffer to the remote service

### DIFF
--- a/sdk/src/main/java/com/deploygate/sdk/Compatibility.java
+++ b/sdk/src/main/java/com/deploygate/sdk/Compatibility.java
@@ -1,0 +1,18 @@
+package com.deploygate.sdk;
+
+final class Compatibility {
+    /**
+     * All values must be *inclusive*. {@link Integer#MAX_VALUE} means the version is not fixed yet.
+     */
+    static final class ClientVersion {
+        /**
+         * older clients crash due to ClassNotFound if SDK sends custom exceptions.
+         */
+        static final int SUPPORT_SERIALIZED_EXCEPTION = 42;
+
+        /**
+         * older clients don't take care of buffered time.
+         */
+        static final int SUPPORT_BUFFERED_TIME_IN_MILLI_SECONDS = Integer.MAX_VALUE;
+    }
+}

--- a/sdk/src/main/java/com/deploygate/sdk/CustomLog.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomLog.java
@@ -1,12 +1,14 @@
 package com.deploygate.sdk;
 
 import android.os.Bundle;
+import android.os.SystemClock;
 
 import com.deploygate.service.DeployGateEvent;
 
 class CustomLog {
     public final String type;
     public final String body;
+    private final long elapsedTime;
     private int retryCount;
 
     CustomLog(
@@ -15,6 +17,7 @@ class CustomLog {
     ) {
         this.type = type;
         this.body = body;
+        this.elapsedTime = SystemClock.elapsedRealtime();
         this.retryCount = 0;
     }
 
@@ -26,12 +29,15 @@ class CustomLog {
     }
 
     /**
+     * This measures the waiting-time in the buffer, so don't hold or reuse the returned value.
+     *
      * @return a bundle to send to the client service
      */
     Bundle toExtras() {
         Bundle extras = new Bundle();
         extras.putSerializable(DeployGateEvent.EXTRA_LOG, body);
         extras.putSerializable(DeployGateEvent.EXTRA_LOG_TYPE, type);
+        extras.putLong(DeployGateEvent.EXTRA_BUFFERED_TIME_IN_MILLI_SECONDS, SystemClock.elapsedRealtime() - elapsedTime);
         return extras;
     }
 }

--- a/sdk/src/main/java/com/deploygate/sdk/CustomLog.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomLog.java
@@ -29,15 +29,13 @@ class CustomLog {
     }
 
     /**
-     * This measures the waiting-time in the buffer, so don't hold or reuse the returned value.
-     *
      * @return a bundle to send to the client service
      */
     Bundle toExtras() {
         Bundle extras = new Bundle();
         extras.putSerializable(DeployGateEvent.EXTRA_LOG, body);
         extras.putSerializable(DeployGateEvent.EXTRA_LOG_TYPE, type);
-        extras.putLong(DeployGateEvent.EXTRA_BUFFERED_TIME_IN_MILLI_SECONDS, SystemClock.elapsedRealtime() - elapsedTime);
+        extras.putLong(DeployGateEvent.EXTRA_BUFFERED_AT_IN_MILLI_SECONDS, elapsedTime);
         return extras;
     }
 }

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -63,8 +63,6 @@ public class DeployGate {
             "234eff4a1600a7aa78bf68adfbb15786e886ae1a",
             };
 
-    private static final int SERIALIZED_EXCEPTION_SUPPORT_CLIENT_VERSION = 42;
-
     private static DeployGate sInstance;
 
     private final Context mApplicationContext;
@@ -1065,7 +1063,7 @@ public class DeployGate {
 
         Bundle extras = new Bundle();
         try {
-            if (getDeployGateVersionCode() >= SERIALIZED_EXCEPTION_SUPPORT_CLIENT_VERSION) {
+            if (getDeployGateVersionCode() >= Compatibility.ClientVersion.SUPPORT_SERIALIZED_EXCEPTION) {
                 Throwable rootCause = getRootCause(ex);
                 String msg = rootCause.getMessage();
                 extras.putString(DeployGateEvent.EXTRA_EXCEPTION_ROOT_CAUSE_CLASSNAME, rootCause.getClass().getName());

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -30,6 +30,7 @@ public interface DeployGateEvent {
     public static final String EXTRA_IS_BOOT = "isBoot";
     public static final String EXTRA_LOG = "log";
     public static final String EXTRA_LOG_TYPE = "logType";
+    public static final String EXTRA_BUFFERED_TIME_IN_MILLI_SECONDS = "bufferedTimeInMs";
 
     /**
      * this key shouldn't be used

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -30,7 +30,7 @@ public interface DeployGateEvent {
     public static final String EXTRA_IS_BOOT = "isBoot";
     public static final String EXTRA_LOG = "log";
     public static final String EXTRA_LOG_TYPE = "logType";
-    public static final String EXTRA_BUFFERED_TIME_IN_MILLI_SECONDS = "bufferedTimeInMs";
+    public static final String EXTRA_BUFFERED_AT_IN_MILLI_SECONDS = "bufferedAt";
 
     /**
      * this key shouldn't be used

--- a/sdk/src/test/java/com/deploygate/sdk/CustomLogTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CustomLogTest.java
@@ -8,6 +8,10 @@ import com.deploygate.sdk.truth.BundleSubject;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.shadows.ShadowSystemClock;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @RunWith(AndroidJUnit4.class)
 public class CustomLogTest {
@@ -16,16 +20,21 @@ public class CustomLogTest {
     public void CustomLog_toExtras_must_be_valid_format() {
         CustomLog log = new CustomLog("error", "yes");
 
-        BundleSubject.assertThat(log.toExtras()).isEqualTo(createLogExtra("error", "yes"));
+        ShadowSystemClock.advanceBy(Duration.ofMillis(123));
+
+        BundleSubject.assertThat(log.toExtras()).isEqualTo(createLogExtra("error", "yes", 123, TimeUnit.MILLISECONDS));
     }
 
     private static Bundle createLogExtra(
             String type,
-            String body
+            String body,
+            long timeInBuffer,
+            TimeUnit timeInBufferUnit
     ) {
         Bundle bundle = new Bundle();
         bundle.putString("logType", type);
         bundle.putString("log", body);
+        bundle.putLong("bufferedTimeInMs", timeInBufferUnit.toMillis(timeInBuffer));
         return bundle;
     }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/CustomLogTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CustomLogTest.java
@@ -1,6 +1,7 @@
 package com.deploygate.sdk;
 
 import android.os.Bundle;
+import android.os.SystemClock;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -11,30 +12,30 @@ import org.junit.runner.RunWith;
 import org.robolectric.shadows.ShadowSystemClock;
 
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 @RunWith(AndroidJUnit4.class)
 public class CustomLogTest {
 
     @Test
     public void CustomLog_toExtras_must_be_valid_format() {
+        long bufferedAt = SystemClock.elapsedRealtime();
+
         CustomLog log = new CustomLog("error", "yes");
 
         ShadowSystemClock.advanceBy(Duration.ofMillis(123));
 
-        BundleSubject.assertThat(log.toExtras()).isEqualTo(createLogExtra("error", "yes", 123, TimeUnit.MILLISECONDS));
+        BundleSubject.assertThat(log.toExtras()).isEqualTo(createLogExtra("error", "yes", bufferedAt));
     }
 
     private static Bundle createLogExtra(
             String type,
             String body,
-            long timeInBuffer,
-            TimeUnit timeInBufferUnit
+            long bufferedAt
     ) {
         Bundle bundle = new Bundle();
         bundle.putString("logType", type);
         bundle.putString("log", body);
-        bundle.putLong("bufferedTimeInMs", timeInBufferUnit.toMillis(timeInBuffer));
+        bundle.putLong("bufferedAt", bufferedAt);
         return bundle;
     }
 }


### PR DESCRIPTION
This measuring relies on `SystemClock.elapsedRealtime` so it's available only for on-memory buffer.