### PR TITLE
Buffer Logcat instructions

### DIFF
--- a/sample/src/main/java/com/deploygate/sample/SampleActivity.java
+++ b/sample/src/main/java/com/deploygate/sample/SampleActivity.java
@@ -83,18 +83,23 @@ public class SampleActivity extends Activity implements DeployGateCallback {
         String text = mLogMessage.getText().toString();
         switch (v.getId()) {
             case R.id.logError:
+                Log.e(TAG, "DeployGate#logError");
                 DeployGate.logError(text);
                 break;
             case R.id.logWarn:
+                Log.w(TAG, "DeployGate#logWarn");
                 DeployGate.logWarn(text);
                 break;
             case R.id.logDebug:
+                Log.d(TAG, "DeployGate#logDebug");
                 DeployGate.logDebug(text);
                 break;
             case R.id.logInfo:
+                Log.i(TAG, "DeployGate#logInfo");
                 DeployGate.logInfo(text);
                 break;
             case R.id.logVerbose:
+                Log.v(TAG, "DeployGate#logVerbose");
                 DeployGate.logVerbose(text);
                 break;
             default:
@@ -109,6 +114,7 @@ public class SampleActivity extends Activity implements DeployGateCallback {
      *         View instance of the button
      */
     public void onCrashMeClick(View v) {
+        Log.d(TAG, "DeployGate#onCrashMeClick");
         // let's throw!
         throw new RuntimeException("CRASH TEST BUTTON CLICKED YAY!");
     }
@@ -120,6 +126,7 @@ public class SampleActivity extends Activity implements DeployGateCallback {
      *         View instance of the button
      */
     public void onLogCatClick(View v) {
+        Log.d(TAG, "DeployGate#requestLogCat");
         DeployGate.requestLogCat();
         Toast.makeText(this, R.string.logcat_toast, Toast.LENGTH_LONG).show();
     }
@@ -131,6 +138,7 @@ public class SampleActivity extends Activity implements DeployGateCallback {
      *         View instance of the button
      */
     public void onUpdateClick(View v) {
+        Log.d(TAG, "DeployGate#installUpdate");
         DeployGate.installUpdate();
     }
 
@@ -142,6 +150,7 @@ public class SampleActivity extends Activity implements DeployGateCallback {
      *         View instance of the button
      */
     public void onCommentsClick(View view) {
+        Log.d(TAG, "DeployGate#openComments");
         DeployGate.openComments();
     }
 

--- a/sdk.build.gradle
+++ b/sdk.build.gradle
@@ -27,6 +27,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+
+    testOptions {
+        unitTests.all {
+            jvmArgs "-Xmx1g"
+        }
+    }
 }
 
 dependencies {

--- a/sdk/src/main/java/com/deploygate/sdk/CustomLogInstructionSerializer.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomLogInstructionSerializer.java
@@ -1,5 +1,6 @@
 package com.deploygate.sdk;
 
+import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
@@ -159,6 +160,18 @@ class CustomLogInstructionSerializer {
         }
 
         return handler.customLogs.size();
+    }
+
+    /**
+     * Only for testing
+     */
+    void halt() {
+        thread.interrupt();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            thread.quitSafely();
+        } else {
+            thread.quit();
+        }
     }
 
     /**

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -171,14 +171,14 @@ public class DeployGate {
     };
 
     private void onOneshotLogcat() {
-        mLogcatInstructionSerializer.request(true);
+        mLogcatInstructionSerializer.requestSendingLogcat(true);
     }
 
     private void onEnableLogcat(boolean isEnabled) {
         mLogcatInstructionSerializer.setDisabled(!isEnabled);
 
         if (isEnabled) {
-            mLogcatInstructionSerializer.request(false);
+            mLogcatInstructionSerializer.requestSendingLogcat(false);
         } else {
             mLogcatInstructionSerializer.cancel();
         }
@@ -291,6 +291,7 @@ public class DeployGate {
                 Log.v(TAG, "DeployGate service disconneced");
                 mRemoteService = null;
                 mCustomLogInstructionSerializer.disconnect();
+                mLogcatInstructionSerializer.disconnect();
             }
         }, Context.BIND_AUTO_CREATE);
     }
@@ -304,6 +305,7 @@ public class DeployGate {
         try {
             mRemoteService.init(mRemoteCallback, mApplicationContext.getPackageName(), args);
             mCustomLogInstructionSerializer.connect(mRemoteService);
+            mLogcatInstructionSerializer.connect(mRemoteService);
         } catch (RemoteException e) {
             Log.w(TAG, "DeployGate service failed to be initialized.");
         }

--- a/sdk/src/main/java/com/deploygate/sdk/ILogcatInstructionSerializer.java
+++ b/sdk/src/main/java/com/deploygate/sdk/ILogcatInstructionSerializer.java
@@ -1,0 +1,69 @@
+package com.deploygate.sdk;
+
+import com.deploygate.sdk.internal.Logger;
+import com.deploygate.service.IDeployGateSdkService;
+
+interface ILogcatInstructionSerializer {
+
+    /**
+     * Bind a service and trigger several instructions immediately.
+     *
+     * @param service
+     *         the latest service connection
+     */
+    void connect(IDeployGateSdkService service);
+
+    /**
+     * Release a service connection and cancel all pending instructions and on-going instruction.
+     */
+    void disconnect();
+
+    /**
+     * Create and enqueue a request to send logcat
+     *
+     * @param isOneShot
+     *         specify true for oneshot logcat, otherwise for streamed logcat
+     */
+    void requestSendingLogcat(boolean isOneShot);
+
+    /**
+     * Enable the logcat process. Serialization won't be disabled.
+     *
+     * @param enabled
+     *         specify true to enable the logcat process
+     */
+    void setEnabled(boolean enabled);
+
+    /**
+     * Cancel the on-going logcat process
+     */
+    void cancel();
+
+    ILogcatInstructionSerializer NULL_INSTANCE = new ILogcatInstructionSerializer() {
+
+        @Override
+        public void connect(IDeployGateSdkService service) {
+            Logger.d("Logcat (no-op): connect");
+        }
+
+        @Override
+        public void disconnect() {
+            Logger.d("Logcat (no-op): disconnect");
+        }
+
+        @Override
+        public void requestSendingLogcat(boolean isOneShot) {
+            Logger.d("Logcat (no-op): requestSendingLogcat(%s)", String.valueOf(isOneShot));
+        }
+
+        @Override
+        public void setEnabled(boolean enabled) {
+            Logger.d("Logcat (no-op): setEnabled(%s)", String.valueOf(enabled));
+        }
+
+        @Override
+        public void cancel() {
+            Logger.d("Logcat (no-op): cancel");
+        }
+    };
+}

--- a/sdk/src/main/java/com/deploygate/sdk/ILogcatInstructionSerializer.java
+++ b/sdk/src/main/java/com/deploygate/sdk/ILogcatInstructionSerializer.java
@@ -24,7 +24,7 @@ interface ILogcatInstructionSerializer {
      * @param isOneShot
      *         specify true for oneshot logcat, otherwise for streamed logcat
      */
-    void requestSendingLogcat(boolean isOneShot);
+    boolean requestSendingLogcat(boolean isOneShot);
 
     /**
      * Enable the logcat process. Serialization won't be disabled.
@@ -52,8 +52,9 @@ interface ILogcatInstructionSerializer {
         }
 
         @Override
-        public void requestSendingLogcat(boolean isOneShot) {
+        public boolean requestSendingLogcat(boolean isOneShot) {
             Logger.d("Logcat (no-op): requestSendingLogcat(%s)", String.valueOf(isOneShot));
+            return false;
         }
 
         @Override

--- a/sdk/src/main/java/com/deploygate/sdk/LogcatInstructionSerializer.java
+++ b/sdk/src/main/java/com/deploygate/sdk/LogcatInstructionSerializer.java
@@ -1,0 +1,371 @@
+package com.deploygate.sdk;
+
+import android.os.Build;
+import android.os.Bundle;
+import android.os.DeadObjectException;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.Looper;
+import android.os.Message;
+import android.os.RemoteException;
+import android.os.TransactionTooLargeException;
+import android.text.TextUtils;
+
+import com.deploygate.sdk.internal.Logger;
+import com.deploygate.service.DeployGateEvent;
+import com.deploygate.service.IDeployGateSdkService;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+class LogcatInstructionSerializer {
+    static final int MAX_RETRY_COUNT = 2;
+    static final int MAX_CHUNK_CHALLENGE_COUNT = 2;
+    static final int SEND_LOGCAT_RESULT_SUCCESS = 0;
+    static final int SEND_LOGCAT_RESULT_FAILURE_REQUEST_CHUNK_CHALLENGE = -1;
+    static final int SEND_LOGCAT_RESULT_FAILURE_ANYWAY = -2;
+
+    private static final Object LOCK = new Object();
+    private static final int BUFFER_SIZE = 8192;
+    // FIXME this should be flexible cuz the transaction needs to be reduced if exceeded.
+    private static final int MAX_LINES = 500;
+
+    private final String packageName;
+
+    @SuppressWarnings("FieldCanBeLocal")
+    private final HandlerThread thread;
+    private LogcatHandler handler;
+    private boolean isDisabledTransmission;
+
+    private volatile IDeployGateSdkService service;
+
+    LogcatInstructionSerializer(
+            String packageName
+    ) {
+        if (TextUtils.isEmpty(packageName)) {
+            throw new IllegalArgumentException("packageName must be present");
+        }
+
+        this.packageName = packageName;
+        this.isDisabledTransmission = false;
+
+        this.thread = new HandlerThread("deploygate-sdk-logcat");
+        this.thread.start();
+    }
+
+    /**
+     * Bind a service and trigger several instructions immediately.
+     *
+     * @param service
+     *         the latest service connection
+     */
+    public final synchronized void connect(IDeployGateSdkService service) {
+        if (service == null) {
+            throw new IllegalArgumentException("service must not be null");
+        }
+
+        ensureHandlerInitialized();
+
+        Boolean isOneShot = handler.cancelPendingSendLogcatInstruction();
+
+        this.service = service;
+
+        if (isOneShot == null) {
+            return;
+        }
+
+        handler.enqueueSendLogcatInstruction(isOneShot);
+    }
+
+    /**
+     * Release a service connection and cancel all pending instructions.
+     */
+    public final void disconnect() {
+        ensureHandlerInitialized();
+
+        handler.cancelPendingSendLogcatInstruction();
+        this.service = null;
+    }
+
+    public final synchronized void request(
+            boolean isOneShot
+    ) {
+        if (isDisabledTransmission) {
+            return;
+        }
+
+        ensureHandlerInitialized();
+        handler.enqueueSendLogcatInstruction(isOneShot);
+    }
+
+    /**
+     * Disable transmissions.
+     *
+     * @param disabledTransmission
+     *         specify true if wanna disable the transmitter, otherwise false.
+     */
+    public final void setDisabledTransmission(boolean disabledTransmission) {
+        isDisabledTransmission = disabledTransmission;
+
+        if (disabledTransmission) {
+            Logger.d("Disabled custom log transmitter");
+        } else {
+            Logger.d("Enabled custom log transmitter");
+        }
+    }
+
+    /**
+     * Check if this transmitter has a service connection.
+     * <p>
+     * The connection may return {@link android.os.DeadObjectException} even if this returns true;
+     *
+     * @return true if a service connection is assigned, otherwise false.
+     */
+    public final boolean hasServiceConnection() {
+        return service != null;
+    }
+
+    /**
+     * @return
+     *
+     * @hide Only for testing.
+     */
+    Looper getLooper() {
+        return handler.getLooper();
+    }
+
+    /**
+     * Send a set of lines to the receiver.
+     * <p>
+     * Visible only for testing
+     *
+     * @param lines
+     *         logcat lines to send
+     *
+     * @return Return {@link LogcatInstructionSerializer#SEND_LOGCAT_RESULT_SUCCESS} if this can transmit the log cat,
+     * or return {@link LogcatInstructionSerializer#SEND_LOGCAT_RESULT_FAILURE_REQUEST_CHUNK_CHALLENGE} if smaller transaction may pass,
+     * otherwise {@link LogcatInstructionSerializer#SEND_LOGCAT_RESULT_FAILURE_ANYWAY}
+     */
+    int sendLogcat(ArrayList<String> lines) {
+        IDeployGateSdkService service = this.service;
+
+        if (service == null) {
+            // never support pending requests
+            return SEND_LOGCAT_RESULT_FAILURE_ANYWAY;
+        }
+
+        Bundle extras = new Bundle();
+        extras.putStringArrayList(DeployGateEvent.EXTRA_LOG, lines);
+
+        int retryCount = 0;
+
+        do {
+            try {
+                service.sendEvent(packageName, DeployGateEvent.ACTION_SEND_LOGCAT, extras);
+                return SEND_LOGCAT_RESULT_SUCCESS;
+            } catch (DeadObjectException e) {
+                return SEND_LOGCAT_RESULT_FAILURE_ANYWAY;
+            } catch (RemoteException e) {
+                if (Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1 <= Build.VERSION.SDK_INT) {
+                    if (e instanceof TransactionTooLargeException) {
+                        return SEND_LOGCAT_RESULT_FAILURE_REQUEST_CHUNK_CHALLENGE;
+                    }
+                }
+            }
+        } while (retryCount++ < MAX_RETRY_COUNT);
+
+        return SEND_LOGCAT_RESULT_FAILURE_ANYWAY;
+    }
+
+    private void ensureHandlerInitialized() {
+        if (handler != null) {
+            return;
+        }
+
+        synchronized (LOCK) {
+            if (handler != null) {
+                return;
+            }
+
+            handler = new LogcatHandler(thread.getLooper(), this);
+        }
+    }
+
+    private static class LogcatHandler extends Handler {
+        private static final int WHAT_SEND_LOGCAT = 0x20;
+
+        private final LogcatInstructionSerializer transmitter;
+
+        LogcatHandler(
+                Looper looper,
+                LogcatInstructionSerializer transmitter
+        ) {
+            super(looper);
+            this.transmitter = transmitter;
+        }
+
+        /**
+         * Cancel the send-logcat instruction in the handler message queue.
+         * This doesn't interrupt the thread and stop the sending-logcat instruction that is running at the time.
+         *
+         * @return nullable. null means no request has been canceled. non-null value is same to isOneShot parameter of the cancled request, so it doesn't mean if cancel succeed or not.
+         */
+        Boolean cancelPendingSendLogcatInstruction() {
+            if (hasMessages(WHAT_SEND_LOGCAT, true)) {
+                removeMessages(WHAT_SEND_LOGCAT);
+                return true;
+            } else if (hasMessages(WHAT_SEND_LOGCAT, false)) {
+                removeMessages(WHAT_SEND_LOGCAT);
+                return false;
+            }
+
+            // dirty implementation :shrug:
+            return null;
+        }
+
+        /**
+         * Enqueue the send-logcat instruction in the handler message queue unless enqueued.
+         *
+         * @param isOneShot
+         *         specify true to send oneshot LogCat, otherwise false.
+         */
+        void enqueueSendLogcatInstruction(boolean isOneShot) {
+            removeMessages(WHAT_SEND_LOGCAT);
+            sendMessage(obtainMessage(WHAT_SEND_LOGCAT, isOneShot));
+        }
+
+        void getAndSendLogcat(boolean isOneShot) {
+            Process process = null;
+            BufferedReader bufferedReader = null;
+
+            try {
+                // ArrayList is the best unless isOneShot. Otherwise, ArrayDeque is the best.
+                //
+                // - add(String) should be O(1)
+                // - remove(0) should be O(1) if isOneShot is true
+                // - toArray should be O(N) to transform itself to ArrayList
+                Collection<String> logcatBuf = isOneShot ? new ArrayDeque<>(MAX_LINES) : new ArrayList<>(MAX_LINES);
+
+                process = Runtime.getRuntime().exec(buildCommands(isOneShot));
+                bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()), BUFFER_SIZE);
+
+                Logger.d("Start retrieving logcat");
+                String line;
+                while ((line = bufferedReader.readLine()) != null) {
+                    logcatBuf.add(line + "\n");
+                    if (isOneShot) {
+                        if (logcatBuf.size() > MAX_LINES) {
+                            ((ArrayDeque<String>) logcatBuf).removeFirst();
+                        }
+                    } else {
+                        if (!bufferedReader.ready()) {
+                            if (sendLogcat(0, logcatBuf) == SEND_LOGCAT_RESULT_SUCCESS) {
+                                logcatBuf.clear();
+                            } else {
+                                return;
+                            }
+                        }
+                    }
+                }
+
+                if (!logcatBuf.isEmpty()) {
+                    sendLogcat(0, logcatBuf);
+                }
+
+                // EOF
+            } catch (IOException e) {
+                Logger.d("Logcat stopped: %s", e.getMessage());
+            } finally {
+                if (bufferedReader != null) {
+                    try {
+                        bufferedReader.close();
+                    } catch (IOException e) {
+                        // ignored
+                    }
+                }
+                try {
+                    if (process != null) {
+                        process.destroy();
+                    }
+                } catch (Throwable th) {
+                    Logger.e(th, "failed to stop the logcat process");
+                }
+            }
+        }
+
+        /**
+         * @param splitCount
+         *         number of times that one transaction has been split.
+         * @param lines
+         *         logcat lines to send
+         *
+         * @return return {@link LogcatInstructionSerializer#SEND_LOGCAT_RESULT_SUCCESS} if succeeded, otherwise {@link LogcatInstructionSerializer#SEND_LOGCAT_RESULT_FAILURE_ANYWAY}
+         */
+        private int sendLogcat(
+                int splitCount,
+                Collection<String> lines
+        ) {
+            ArrayList<String> serializee = lines instanceof ArrayList ? (ArrayList<String>) lines : new ArrayList<>(lines);
+
+            int result = transmitter.sendLogcat(serializee);
+
+            if (result != SEND_LOGCAT_RESULT_FAILURE_REQUEST_CHUNK_CHALLENGE) {
+                return result;
+            }
+
+            if (splitCount >= MAX_CHUNK_CHALLENGE_COUNT) {
+                // terminate this request due to too many attempts.
+                return SEND_LOGCAT_RESULT_FAILURE_ANYWAY;
+            }
+
+            int partitionIndex = serializee.size();
+
+            if (sendLogcat(splitCount + 1, serializee.subList(0, partitionIndex)) != SEND_LOGCAT_RESULT_SUCCESS) {
+                return SEND_LOGCAT_RESULT_FAILURE_ANYWAY;
+            }
+
+            return sendLogcat(splitCount + 1, serializee.subList(partitionIndex, serializee.size()));
+        }
+
+        /**
+         * @param isOneShot
+         *         true if oneshot logcat is requested
+         *
+         * @return an array for command-exec
+         */
+        private String[] buildCommands(boolean isOneShot) {
+            List<String> commandLine = new ArrayList<>();
+            commandLine.add("logcat");
+
+            int MAX_LINES = 500;
+            if (isOneShot) {
+                commandLine.add("-d");
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.FROYO) {
+                    commandLine.add("-t");
+                    commandLine.add(String.valueOf(MAX_LINES));
+                }
+            }
+            commandLine.add("-v");
+            commandLine.add("threadtime");
+            commandLine.add("*:V");
+
+            return commandLine.toArray(new String[0]);
+        }
+
+        @Override
+        public void handleMessage(Message msg) {
+            switch (msg.what) {
+                case WHAT_SEND_LOGCAT: {
+                    getAndSendLogcat((Boolean) msg.obj);
+
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/sdk/src/main/java/com/deploygate/sdk/LogcatProcess.java
+++ b/sdk/src/main/java/com/deploygate/sdk/LogcatProcess.java
@@ -3,8 +3,6 @@ package com.deploygate.sdk;
 import android.os.Build;
 import android.util.Pair;
 
-import com.deploygate.sdk.internal.Config;
-import com.deploygate.sdk.internal.Factory;
 import com.deploygate.sdk.internal.Logger;
 
 import java.io.BufferedReader;
@@ -38,11 +36,6 @@ class LogcatProcess {
     private static final Object LOCK = new Object();
 
     static final int MAX_LINES = 500; // plus 1 due to the legacy behavior
-
-    /**
-     * Only for testing
-     */
-    static Factory<Process> sLogcatProcessFactory;
 
     private final LogcatProcess.Callback callback;
     private final ExecutorService executorService;
@@ -290,16 +283,12 @@ class LogcatProcess {
             return isOneShot ? new ArrayDeque<String>(size) : new ArrayList<String>(size);
         }
 
-        private static ArrayList<String> toArrayList(Collection<String> collection) {
+        static ArrayList<String> toArrayList(Collection<String> collection) {
             return collection instanceof ArrayList ? (ArrayList<String>) collection : new ArrayList<>(collection);
         }
 
-        private static Process execLogcatCommand(boolean isOneShot) throws IOException {
-            if (!Config.DEBUG) {
-                return Runtime.getRuntime().exec(buildCommands(isOneShot));
-            }
-
-            return sLogcatProcessFactory.create();
+        static Process execLogcatCommand(boolean isOneShot) throws IOException {
+            return Runtime.getRuntime().exec(buildCommands(isOneShot));
         }
 
         /**

--- a/sdk/src/main/java/com/deploygate/sdk/LogcatProcess.java
+++ b/sdk/src/main/java/com/deploygate/sdk/LogcatProcess.java
@@ -1,0 +1,321 @@
+package com.deploygate.sdk;
+
+import android.os.Build;
+import android.util.Pair;
+
+import com.deploygate.sdk.internal.Config;
+import com.deploygate.sdk.internal.Factory;
+import com.deploygate.sdk.internal.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.ref.WeakReference;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+class LogcatProcess {
+    interface Callback {
+        void emit(
+                String watchId,
+                ArrayList<String> logcatLines
+        );
+    }
+
+    static final String UNKNOWN_WATCHER_ID = "UNKNOWN";
+
+    private static final int BUFFER_SIZE = 8192;
+    // FIXME this should be flexible cuz the transaction needs to be reduced if exceeded.
+    private static final Object LOCK = new Object();
+
+    static final int MAX_LINES = 500; // plus 1 due to the legacy behavior
+
+    /**
+     * Only for testing
+     */
+    static Factory<Process> sLogcatProcessFactory;
+
+    private final LogcatProcess.Callback callback;
+    private final ExecutorService executorService;
+    private LogcatWatcher latestLogcatWatcher;
+
+    LogcatProcess(
+            LogcatProcess.Callback callback
+    ) {
+        this.callback = callback;
+        this.executorService = Executors.newFixedThreadPool(1);
+    }
+
+    /**
+     * @param isOneShot
+     *
+     * @return a pair of watcher ids (non-nulls). first is the previous watcher id, second is the new watcher id.
+     */
+    Pair<String, String> execute(boolean isOneShot) {
+        final LogcatWatcher newWatcher;
+        final String currentWatchId;
+
+        synchronized (LOCK) {
+            if (latestLogcatWatcher != null) {
+                currentWatchId = latestLogcatWatcher.watchId;
+            } else {
+                currentWatchId = UNKNOWN_WATCHER_ID;
+            }
+
+            if (latestLogcatWatcher != null && latestLogcatWatcher.isAlive()) {
+                return Pair.create(UNKNOWN_WATCHER_ID, currentWatchId);
+            }
+
+            newWatcher = new LogcatWatcher(isOneShot, callback);
+
+            try {
+                this.latestLogcatWatcher = newWatcher;
+                this.executorService.submit(newWatcher);
+                return Pair.create(currentWatchId, newWatcher.watchId);
+            } catch (RejectedExecutionException th) {
+                Logger.e(th, "cannot schedule the logcat worker");
+                this.latestLogcatWatcher = null;
+                return Pair.create(currentWatchId, UNKNOWN_WATCHER_ID);
+            }
+        }
+    }
+
+    /**
+     * Cancel the on-going watcher.
+     *
+     * @return canceled watch id. {@link LogcatProcess#UNKNOWN_WATCHER_ID}
+     */
+    String stop() {
+        synchronized (LOCK) {
+            if (latestLogcatWatcher == null || !latestLogcatWatcher.isAlive()) {
+                return UNKNOWN_WATCHER_ID;
+            }
+
+            latestLogcatWatcher.interrupt();
+            return latestLogcatWatcher.watchId;
+        }
+    }
+
+    static class LogcatWatcher implements Runnable {
+        private static final int STATE_READY = 0;
+        private static final int STATE_RUNNING = 1;
+        private static final int STATE_INTERRUPTED = 2;
+        private static final int STATE_FINISHED = 3;
+
+        private final boolean isOneShot;
+        private final WeakReference<Callback> callback;
+        private final AtomicReference<Process> processRef;
+        private final String watchId;
+        private final AtomicInteger state;
+
+        LogcatWatcher(
+                boolean isOneShot,
+                Callback callback
+        ) {
+            this.isOneShot = isOneShot;
+            this.callback = new WeakReference<>(callback);
+            this.processRef = new AtomicReference<>();
+            this.watchId = UUID.randomUUID().toString();
+            this.state = new AtomicInteger(STATE_READY);
+        }
+
+        synchronized boolean isAlive() {
+            int state = this.state.get();
+
+            return state == STATE_READY || state == STATE_RUNNING;
+        }
+
+        /**
+         * Interrupt the process of Logcat but never interrupt the thread itself.
+         */
+        void interrupt() {
+            if (!(state.compareAndSet(STATE_READY, STATE_INTERRUPTED) || state.compareAndSet(STATE_RUNNING, STATE_INTERRUPTED))) {
+                return;
+            }
+
+            Process process = processRef.getAndSet(null);
+
+            if (process != null) {
+                try {
+                    process.destroy();
+                } catch (Throwable th) {
+                    Logger.e(th, "an unexpected error happened when destroying the process");
+                }
+            }
+        }
+
+        /**
+         * Only for testing
+         *
+         * @return
+         */
+        String getWatchId() {
+            return watchId;
+        }
+
+        @Override
+        public void run() {
+            if (!state.compareAndSet(STATE_READY, STATE_RUNNING)) {
+                Logger.w("Logcat stream is not ready to execute");
+                return;
+            }
+
+            BufferedReader bufferedReader = null;
+
+            try {
+                Collection<String> logcatBuf = createBuffer(MAX_LINES);
+
+                Process process = execLogcatCommand(isOneShot);
+                processRef.set(process);
+                bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()), BUFFER_SIZE);
+
+                Logger.d("Start retrieving logcat");
+                String line;
+                while ((line = bufferedReader.readLine()) != null) {
+                    Callback callback = this.callback.get();
+
+                    if (callback == null) {
+                        return;
+                    }
+
+                    if (isOneShot) {
+                        if (logcatBuf.size() >= MAX_LINES) {
+                            if (logcatBuf instanceof Deque) {
+                                ((Deque<String>) logcatBuf).removeFirst();
+                            } else if (logcatBuf instanceof List) {
+                                ((List<String>) logcatBuf).remove(0);
+                            } else {
+                                throw new IllegalStateException("non-allowed collection class");
+                            }
+                        }
+                    }
+
+                    logcatBuf.add(line + "\n");
+
+                    // check before emitting
+                    if (state.get() != STATE_RUNNING) {
+                        Logger.w("Logcat stream is interrupted");
+                        return;
+                    }
+
+                    if (isOneShot) {
+                        continue;
+                    } else if (logcatBuf.size() >= MAX_LINES) {
+                        callback.emit(watchId, toArrayList(logcatBuf));
+                        logcatBuf = createBuffer(MAX_LINES); // Don't reuse to make sure releasing the reference
+                    } else if (!bufferedReader.ready()) {
+                        callback.emit(watchId, toArrayList(logcatBuf));
+                        logcatBuf = createBuffer(MAX_LINES); // Don't reuse to make sure releasing the reference
+                    } else {
+                        continue;
+                    }
+
+                    // check after emitting
+                    if (state.get() != STATE_RUNNING) {
+                        Logger.w("Logcat stream is interrupted");
+                        return;
+                    }
+                }
+
+                if (!logcatBuf.isEmpty()) {
+                    Callback callback = this.callback.get();
+
+                    if (callback != null) {
+                        callback.emit(watchId, toArrayList(logcatBuf));
+                    }
+                }
+
+                // EOF
+            } catch (IOException e) {
+                Logger.d("Logcat stopped: %s", e.getMessage());
+            } catch (SecurityException e) {
+                // FIXME notify this to the parent
+                Logger.e("Subprocess is unavailable: %s", e.getMessage());
+            } finally {
+                if (!state.compareAndSet(STATE_RUNNING, STATE_FINISHED)) {
+                    Logger.w("this process has already been interrupted");
+                }
+
+                Process process = processRef.getAndSet(null);
+
+                if (bufferedReader != null) {
+                    try {
+                        bufferedReader.close();
+                    } catch (IOException e) {
+                        // ignored
+                    }
+                }
+                if (process != null) {
+                    try {
+                        process.destroy();
+                    } catch (Throwable th) {
+                        Logger.e(th, "an unexpected error happened when destroying the process");
+                    }
+                }
+            }
+        }
+
+        /**
+         * ArrayList is the best unless isOneShot. Otherwise, ArrayDeque is the best.
+         * - add(String) should be O(1)
+         * - remove(0) should be O(1) if isOneShot is true
+         * - toArray should be O(N) to transform itself to ArrayList
+         *
+         * @param size
+         *         the capacity of the buffer (the actual collection class may adjust the cap based on this parameter)
+         *
+         * @return a buffer pool
+         */
+        private Collection<String> createBuffer(int size) {
+            return isOneShot ? new ArrayDeque<>(size) : new ArrayList<>(size);
+        }
+
+        private static ArrayList<String> toArrayList(Collection<String> collection) {
+            return collection instanceof ArrayList ? (ArrayList<String>) collection : new ArrayList<>(collection);
+        }
+
+        private static Process execLogcatCommand(boolean isOneShot) throws IOException {
+            if (!Config.DEBUG) {
+                return Runtime.getRuntime().exec(buildCommands(isOneShot));
+            }
+
+            return sLogcatProcessFactory.create();
+        }
+
+        /**
+         * @param isOneShot
+         *         true if oneshot logcat is requested
+         *
+         * @return an array for command-exec
+         */
+        private static String[] buildCommands(boolean isOneShot) {
+            List<String> commandLine = new ArrayList<>();
+            commandLine.add("logcat");
+
+            int MAX_LINES = 500;
+            if (isOneShot) {
+                commandLine.add("-d");
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.FROYO) {
+                    commandLine.add("-t");
+                    commandLine.add(String.valueOf(MAX_LINES));
+                }
+            }
+            commandLine.add("-v");
+            commandLine.add("threadtime");
+            commandLine.add("*:V");
+
+            return commandLine.toArray(new String[0]);
+        }
+    }
+}
+
+

--- a/sdk/src/main/java/com/deploygate/sdk/SendLogcatRequest.java
+++ b/sdk/src/main/java/com/deploygate/sdk/SendLogcatRequest.java
@@ -1,0 +1,68 @@
+package com.deploygate.sdk;
+
+import android.os.Bundle;
+
+import com.deploygate.sdk.internal.Logger;
+import com.deploygate.service.DeployGateEvent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+class SendLogcatRequest {
+    public final String watchId;
+    public final ArrayList<String> lines;
+    private int retryCount;
+
+    SendLogcatRequest(
+            String watchId,
+            List<String> lines
+    ) {
+        this.watchId = watchId;
+        this.lines = lines instanceof ArrayList ? (ArrayList<String>) lines : new ArrayList<>(lines);
+    }
+
+    /**
+     * @return the number of current attempts
+     */
+    int getAndIncrementRetryCount() {
+        return retryCount++;
+    }
+
+    List<SendLogcatRequest> splitInto(int count) {
+        if (count <= 0) {
+            throw new IllegalArgumentException(String.format(Locale.US, "split count must be greater than 1 but %d", count));
+        }
+
+        if (count == 1) {
+            return Collections.singletonList(this);
+        }
+
+        int size = lines.size();
+
+        if (count >= size) {
+            Logger.w("split count is too large");
+            count = size;
+        }
+
+        List<SendLogcatRequest> splits = new ArrayList<>();
+
+        for (int i = 0, offset = 0, step = size / count; i < count; i++, offset += step) {
+            final int endIndex = (i == count - 1) ? size : offset + step;
+
+            splits.add(new SendLogcatRequest(watchId, lines.subList(offset, endIndex)));
+        }
+
+        return splits;
+    }
+
+    Bundle toExtras() {
+        Bundle extras = new Bundle();
+
+        extras.putStringArrayList(DeployGateEvent.EXTRA_LOG, lines);
+        extras.putString(DeployGateEvent.EXTRA_LOG_CLIENT_ID, watchId);
+
+        return extras;
+    }
+}

--- a/sdk/src/main/java/com/deploygate/sdk/SendLogcatRequest.java
+++ b/sdk/src/main/java/com/deploygate/sdk/SendLogcatRequest.java
@@ -11,15 +11,17 @@ import java.util.List;
 import java.util.Locale;
 
 class SendLogcatRequest {
-    public final String watchId;
+    public final String bundleId;
+    public final String uid;
     public final ArrayList<String> lines;
     private int retryCount;
 
     SendLogcatRequest(
-            String watchId,
+            String bundleId,
             List<String> lines
     ) {
-        this.watchId = watchId;
+        this.bundleId = bundleId;
+        this.uid = UniqueId.generate();
         this.lines = lines instanceof ArrayList ? (ArrayList<String>) lines : new ArrayList<>(lines);
     }
 
@@ -51,7 +53,7 @@ class SendLogcatRequest {
         for (int i = 0, offset = 0, step = size / count; i < count; i++, offset += step) {
             final int endIndex = (i == count - 1) ? size : offset + step;
 
-            splits.add(new SendLogcatRequest(watchId, lines.subList(offset, endIndex)));
+            splits.add(new SendLogcatRequest(bundleId, lines.subList(offset, endIndex)));
         }
 
         return splits;
@@ -60,8 +62,9 @@ class SendLogcatRequest {
     Bundle toExtras() {
         Bundle extras = new Bundle();
 
+        extras.putString(DeployGateEvent.EXTRA_BUNDLE_ID, bundleId);
+        extras.putString(DeployGateEvent.EXTRA_UID, uid);
         extras.putStringArrayList(DeployGateEvent.EXTRA_LOG, lines);
-        extras.putString(DeployGateEvent.EXTRA_LOG_CLIENT_ID, watchId);
 
         return extras;
     }

--- a/sdk/src/main/java/com/deploygate/sdk/internal/Factory.java
+++ b/sdk/src/main/java/com/deploygate/sdk/internal/Factory.java
@@ -1,5 +1,0 @@
-package com.deploygate.sdk.internal;
-
-public interface Factory<T> {
-    T create();
-}

--- a/sdk/src/main/java/com/deploygate/sdk/internal/Factory.java
+++ b/sdk/src/main/java/com/deploygate/sdk/internal/Factory.java
@@ -1,0 +1,5 @@
+package com.deploygate.sdk.internal;
+
+public interface Factory<T> {
+    T create();
+}

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -32,6 +32,7 @@ public interface DeployGateEvent {
     public static final String EXTRA_LOG_TYPE = "logType";
     public static final String EXTRA_BUFFERED_AT_IN_MILLI_SECONDS = "bufferedAt";
     public static final String EXTRA_UID = "uid";
+    public static final String EXTRA_LOG_CLIENT_ID = "logId";
 
     /**
      * this key shouldn't be used

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -31,8 +31,16 @@ public interface DeployGateEvent {
     public static final String EXTRA_LOG = "log";
     public static final String EXTRA_LOG_TYPE = "logType";
     public static final String EXTRA_BUFFERED_AT_IN_MILLI_SECONDS = "bufferedAt";
+
+    /**
+     * the unique id to identify data
+     */
     public static final String EXTRA_UID = "uid";
-    public static final String EXTRA_LOG_CLIENT_ID = "logId";
+
+    /**
+     * id of a bundle that collects instructions (data)
+     */
+    public static final String EXTRA_BUNDLE_ID = "bid";
 
     /**
      * this key shouldn't be used

--- a/sdk/src/test/java/com/deploygate/sdk/LogcatInstructionSerializerTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/LogcatInstructionSerializerTest.java
@@ -1,5 +1,6 @@
 package com.deploygate.sdk;
 
+import android.os.Bundle;
 import android.os.RemoteException;
 import android.os.TransactionTooLargeException;
 
@@ -27,6 +28,7 @@ import java.util.Random;
 
 import static com.deploygate.sdk.mockito.BundleMatcher.eq;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -82,7 +84,7 @@ public class LogcatInstructionSerializerTest {
         SendLogcatRequest chunk2 = new SendLogcatRequest("watchId2", new ArrayList<>(Arrays.asList("line4", "line5", "line6")));
         SendLogcatRequest chunk3 = new SendLogcatRequest("watchId3", new ArrayList<>(Arrays.asList("line7", "line8", "line9")));
 
-        doNothing().when(service).sendEvent(any(), any(), any());
+        doNothing().when(service).sendEvent(anyString(), anyString(), any(Bundle.class));
 
         Truth.assertThat(instructionSerializer.sendSingleChunk(chunk1)).isEqualTo(LogcatInstructionSerializer.SEND_LOGCAT_RESULT_FAILURE_RETRIABLE);
         Truth.assertThat(instructionSerializer.sendSingleChunk(chunk2)).isEqualTo(LogcatInstructionSerializer.SEND_LOGCAT_RESULT_FAILURE_RETRIABLE);
@@ -139,16 +141,14 @@ public class LogcatInstructionSerializerTest {
         instructionSerializer.setEnabled(false);
 
         for (int i = 0; i < 30; i++) {
-            instructionSerializer.requestSendingLogcat(i % 2 == 0);
+            Truth.assertThat(instructionSerializer.requestSendingLogcat(i % 2 == 0)).isFalse();
         }
-
-        Truth.assertThat(instructionSerializer.hasHandlerPrepared()).isFalse();
 
         // Even if a service connection is established, this does nothing.
         instructionSerializer.connect(service);
 
         for (int i = 0; i < 30; i++) {
-            instructionSerializer.requestSendingLogcat(i % 2 == 0);
+            Truth.assertThat(instructionSerializer.requestSendingLogcat(i % 2 == 0)).isFalse();
         }
 
         Shadows.shadowOf(instructionSerializer.getHandler().getLooper()).idle();

--- a/sdk/src/test/java/com/deploygate/sdk/LogcatInstructionSerializerTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/LogcatInstructionSerializerTest.java
@@ -103,9 +103,9 @@ public class LogcatInstructionSerializerTest {
 
         instructionSerializer.requestSendingLogcat(true);
 
-        SendLogcatRequest chunk1 = new SendLogcatRequest("watchId1", new ArrayList<>(Arrays.asList("line1", "line2", "line3")));
-        SendLogcatRequest chunk2 = new SendLogcatRequest("watchId2", new ArrayList<>(Arrays.asList("line4", "line5", "line6")));
-        SendLogcatRequest chunk3 = new SendLogcatRequest("watchId3", new ArrayList<>(Arrays.asList("line7", "line8", "line9")));
+        SendLogcatRequest chunk1 = new SendLogcatRequest("tid1", new ArrayList<>(Arrays.asList("line1", "line2", "line3")));
+        SendLogcatRequest chunk2 = new SendLogcatRequest("tid2", new ArrayList<>(Arrays.asList("line4", "line5", "line6")));
+        SendLogcatRequest chunk3 = new SendLogcatRequest("tid3", new ArrayList<>(Arrays.asList("line7", "line8", "line9")));
 
         doNothing().when(service).sendEvent(anyString(), anyString(), any(Bundle.class));
 

--- a/sdk/src/test/java/com/deploygate/sdk/LogcatInstructionSerializerTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/LogcatInstructionSerializerTest.java
@@ -96,7 +96,7 @@ public class LogcatInstructionSerializerTest {
         instructionSerializer = new LogcatInstructionSerializer(PACKAGE_NAME);
         instructionSerializer.connect(service);
 
-        Shadows.shadowOf(instructionSerializer.getLooper()).pause();
+        Shadows.shadowOf(instructionSerializer.getHandler().getLooper()).pause();
 
         SendLogcatRequest noIssue = new SendLogcatRequest("noIssue", new ArrayList<>(Arrays.asList("line1", "line2", "line3")));
         SendLogcatRequest successAfterRetries = new SendLogcatRequest("successAfterRetries", new ArrayList<>(Arrays.asList("line4", "line5", "line6")));
@@ -127,7 +127,7 @@ public class LogcatInstructionSerializerTest {
             instructionSerializer.requestSendingLogcat(true);
         }
 
-        Shadows.shadowOf(instructionSerializer.getLooper()).idle();
+        Shadows.shadowOf(instructionSerializer.getHandler().getLooper()).idle();
 
         // don't fail
     }
@@ -136,13 +136,13 @@ public class LogcatInstructionSerializerTest {
     public void requestSendingLogcat_does_nothing_if_disabled() throws RemoteException {
         instructionSerializer = new LogcatInstructionSerializer(PACKAGE_NAME);
 
-        instructionSerializer.setDisabled(true);
+        instructionSerializer.setEnabled(false);
 
         for (int i = 0; i < 30; i++) {
             instructionSerializer.requestSendingLogcat(i % 2 == 0);
         }
 
-        Truth.assertThat(instructionSerializer.hasHandlerInitialized()).isFalse();
+        Truth.assertThat(instructionSerializer.hasHandlerPrepared()).isFalse();
 
         // Even if a service connection is established, this does nothing.
         instructionSerializer.connect(service);
@@ -151,7 +151,7 @@ public class LogcatInstructionSerializerTest {
             instructionSerializer.requestSendingLogcat(i % 2 == 0);
         }
 
-        Shadows.shadowOf(instructionSerializer.getLooper()).idle();
+        Shadows.shadowOf(instructionSerializer.getHandler().getLooper()).idle();
 
         Truth.assertThat(instructionSerializer.getHandler().hasMessages(LogcatInstructionSerializer.WHAT_SEND_LOGCAT)).isFalse();
     }

--- a/sdk/src/test/java/com/deploygate/sdk/LogcatInstructionSerializerTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/LogcatInstructionSerializerTest.java
@@ -1,0 +1,158 @@
+package com.deploygate.sdk;
+
+import android.os.RemoteException;
+import android.os.TransactionTooLargeException;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.deploygate.sdk.helper.FakeLogcat;
+import com.deploygate.sdk.internal.Factory;
+import com.deploygate.sdk.mockito.BundleMatcher;
+import com.deploygate.service.DeployGateEvent;
+import com.deploygate.service.FakeDeployGateClientService;
+import com.google.common.truth.Truth;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static com.deploygate.sdk.mockito.BundleMatcher.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.robolectric.annotation.LooperMode.Mode.PAUSED;
+
+@RunWith(AndroidJUnit4.class)
+@LooperMode(PAUSED)
+public class LogcatInstructionSerializerTest {
+
+    private static final String PACKAGE_NAME = "com.deploygate.sample";
+
+    private FakeDeployGateClientService service;
+    private LogcatInstructionSerializer instructionSerializer;
+    private List<Process> processes;
+
+    @Before
+    public void before() {
+        service = Mockito.spy(new FakeDeployGateClientService(PACKAGE_NAME));
+        processes = new ArrayList<>();
+        LogcatProcess.sLogcatProcessFactory = new Factory<Process>() {
+            private final Random RANDOM = new Random();
+
+            @Override
+            public Process create() {
+                FakeLogcat logcat = new FakeLogcat(Math.max(1, RANDOM.nextInt(700)));
+                processes.add(logcat);
+                return logcat;
+            }
+        };
+    }
+
+    @After
+    public void after() {
+        if (instructionSerializer != null) {
+            instructionSerializer.disconnect();
+            instructionSerializer.halt();
+        }
+
+        for (Process process: processes) {
+            if (process.isAlive()) {
+                process.destroy();
+            }
+        }
+    }
+
+    @Test(timeout = 3000L)
+    public void sendSingleChunk_always_returns_retriable_status_if_service_is_none() throws RemoteException {
+        instructionSerializer = new LogcatInstructionSerializer(PACKAGE_NAME);
+
+        instructionSerializer.requestSendingLogcat(true);
+
+        SendLogcatRequest chunk1 = new SendLogcatRequest("watchId1", new ArrayList<>(Arrays.asList("line1", "line2", "line3")));
+        SendLogcatRequest chunk2 = new SendLogcatRequest("watchId2", new ArrayList<>(Arrays.asList("line4", "line5", "line6")));
+        SendLogcatRequest chunk3 = new SendLogcatRequest("watchId3", new ArrayList<>(Arrays.asList("line7", "line8", "line9")));
+
+        doNothing().when(service).sendEvent(any(), any(), any());
+
+        Truth.assertThat(instructionSerializer.sendSingleChunk(chunk1)).isEqualTo(LogcatInstructionSerializer.SEND_LOGCAT_RESULT_FAILURE_RETRIABLE);
+        Truth.assertThat(instructionSerializer.sendSingleChunk(chunk2)).isEqualTo(LogcatInstructionSerializer.SEND_LOGCAT_RESULT_FAILURE_RETRIABLE);
+        Truth.assertThat(instructionSerializer.sendSingleChunk(chunk3)).isEqualTo(LogcatInstructionSerializer.SEND_LOGCAT_RESULT_FAILURE_RETRIABLE);
+
+        Mockito.verifyNoInteractions(service);
+    }
+
+    @Test(timeout = 3000L)
+    public void sendSingleChunk_uses_retry_barrier() throws RemoteException {
+        instructionSerializer = new LogcatInstructionSerializer(PACKAGE_NAME);
+        instructionSerializer.connect(service);
+
+        Shadows.shadowOf(instructionSerializer.getLooper()).pause();
+
+        SendLogcatRequest noIssue = new SendLogcatRequest("noIssue", new ArrayList<>(Arrays.asList("line1", "line2", "line3")));
+        SendLogcatRequest successAfterRetries = new SendLogcatRequest("successAfterRetries", new ArrayList<>(Arrays.asList("line4", "line5", "line6")));
+        SendLogcatRequest retryExceeded = new SendLogcatRequest("retryExceeded", new ArrayList<>(Arrays.asList("line7", "line8", "line9")));
+        SendLogcatRequest chunkRequest = new SendLogcatRequest("chunkRequest", new ArrayList<>(Arrays.asList("line10", "line11", "line12")));
+
+        doNothing().when(service).sendEvent(eq(PACKAGE_NAME), eq(DeployGateEvent.ACTION_SEND_LOGCAT), BundleMatcher.eq(noIssue.toExtras()));
+        doThrow(RemoteException.class).doNothing().when(service).sendEvent(eq(PACKAGE_NAME), eq(DeployGateEvent.ACTION_SEND_LOGCAT), eq(successAfterRetries.toExtras()));
+        doThrow(RemoteException.class).when(service).sendEvent(eq(PACKAGE_NAME), eq(DeployGateEvent.ACTION_SEND_LOGCAT), eq(retryExceeded.toExtras()));
+        doThrow(TransactionTooLargeException.class).doNothing().when(service).sendEvent(eq(PACKAGE_NAME), eq(DeployGateEvent.ACTION_SEND_LOGCAT), eq(chunkRequest.toExtras()));
+
+        Truth.assertThat(instructionSerializer.sendSingleChunk(noIssue)).isEqualTo(LogcatInstructionSerializer.SEND_LOGCAT_RESULT_SUCCESS);
+        Truth.assertThat(instructionSerializer.sendSingleChunk(successAfterRetries)).isEqualTo(LogcatInstructionSerializer.SEND_LOGCAT_RESULT_FAILURE_RETRIABLE);
+        Truth.assertThat(instructionSerializer.sendSingleChunk(successAfterRetries)).isEqualTo(LogcatInstructionSerializer.SEND_LOGCAT_RESULT_SUCCESS);
+        Truth.assertThat(instructionSerializer.sendSingleChunk(retryExceeded)).isEqualTo(LogcatInstructionSerializer.SEND_LOGCAT_RESULT_FAILURE_RETRIABLE);
+        Truth.assertThat(instructionSerializer.sendSingleChunk(retryExceeded)).isEqualTo(LogcatInstructionSerializer.SEND_LOGCAT_RESULT_FAILURE_RETRIABLE);
+        Truth.assertThat(instructionSerializer.sendSingleChunk(retryExceeded)).isEqualTo(LogcatInstructionSerializer.SEND_LOGCAT_RESULT_FAILURE_RETRY_EXCEEDED);
+        Truth.assertThat(instructionSerializer.sendSingleChunk(chunkRequest)).isEqualTo(LogcatInstructionSerializer.SEND_LOGCAT_RESULT_FAILURE_REQUEST_CHUNK_CHALLENGE);
+    }
+
+    @Test(timeout = 3000L)
+    public void requestSendingLogcat_works_regardless_of_service() throws RemoteException {
+        instructionSerializer = new LogcatInstructionSerializer(PACKAGE_NAME);
+
+        // Don't connect a service
+
+        for (int i = 0; i < 10; i++) {
+            instructionSerializer.requestSendingLogcat(true);
+        }
+
+        Shadows.shadowOf(instructionSerializer.getLooper()).idle();
+
+        // don't fail
+    }
+
+    @Test(timeout = 3000L)
+    public void requestSendingLogcat_does_nothing_if_disabled() throws RemoteException {
+        instructionSerializer = new LogcatInstructionSerializer(PACKAGE_NAME);
+
+        instructionSerializer.setDisabled(true);
+
+        for (int i = 0; i < 30; i++) {
+            instructionSerializer.requestSendingLogcat(i % 2 == 0);
+        }
+
+        Truth.assertThat(instructionSerializer.hasHandlerInitialized()).isFalse();
+
+        // Even if a service connection is established, this does nothing.
+        instructionSerializer.connect(service);
+
+        for (int i = 0; i < 30; i++) {
+            instructionSerializer.requestSendingLogcat(i % 2 == 0);
+        }
+
+        Shadows.shadowOf(instructionSerializer.getLooper()).idle();
+
+        Truth.assertThat(instructionSerializer.getHandler().hasMessages(LogcatInstructionSerializer.WHAT_SEND_LOGCAT)).isFalse();
+    }
+}

--- a/sdk/src/test/java/com/deploygate/sdk/LogcatProcessTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/LogcatProcessTest.java
@@ -3,6 +3,7 @@ package com.deploygate.sdk;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.deploygate.sdk.helper.FakeLogcat;
+import com.deploygate.sdk.internal.Factory;
 import com.google.common.truth.Truth;
 
 import org.junit.After;
@@ -23,7 +24,12 @@ public class LogcatProcessTest {
 
     @Before
     public void before() {
-        LogcatProcess.sLogcatProcessFactory = () -> fakeLogcat;
+        LogcatProcess.sLogcatProcessFactory = new Factory<Process>() {
+            @Override
+            public Process create() {
+                return fakeLogcat;
+            }
+        };
     }
 
     @After
@@ -49,7 +55,7 @@ public class LogcatProcessTest {
 
             Truth.assertThat(linesList).hasSize(1);
             Truth.assertThat(linesList.get(0)).hasSize(10);
-            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(fakeLogcat.getGeneratedLines().stream().map(s -> s + "\n").collect(Collectors.toList()));
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(fakeLogcat.getGeneratedLines());
         } finally {
             if (fakeLogcat != null) {
                 fakeLogcat.destroy();
@@ -62,7 +68,7 @@ public class LogcatProcessTest {
 
             watcher.run();
 
-            List<String> generatedLineWithLF = fakeLogcat.getGeneratedLines().stream().map(s -> s + "\n").collect(Collectors.toList());
+            List<String> generatedLineWithLF = fakeLogcat.getGeneratedLines();
 
             List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
 
@@ -83,15 +89,15 @@ public class LogcatProcessTest {
 
             watcher.run();
 
-            List<String> generatedLineWithLF = fakeLogcat.getGeneratedLines().stream().map(s -> s + "\n").collect(Collectors.toList());
+            List<String> generatedLineWithLF = fakeLogcat.getGeneratedLines();
 
             List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
 
             Truth.assertThat(linesList).hasSize(2);
             Truth.assertThat(linesList.get(0)).hasSize(LogcatProcess.MAX_LINES);
-            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(generatedLineWithLF.stream().limit(LogcatProcess.MAX_LINES).collect(Collectors.toList()));
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(generatedLineWithLF.subList(0, LogcatProcess.MAX_LINES));
             Truth.assertThat(linesList.get(1)).hasSize(LogcatProcess.MAX_LINES);
-            Truth.assertThat(linesList.get(1)).containsExactlyElementsIn(generatedLineWithLF.stream().skip(LogcatProcess.MAX_LINES).limit(LogcatProcess.MAX_LINES).collect(Collectors.toList()));
+            Truth.assertThat(linesList.get(1)).containsExactlyElementsIn(generatedLineWithLF.subList(LogcatProcess.MAX_LINES, generatedLineWithLF.size()));
         } finally {
             if (fakeLogcat != null) {
                 fakeLogcat.destroy();
@@ -113,7 +119,7 @@ public class LogcatProcessTest {
 
             Truth.assertThat(linesList).hasSize(1);
             Truth.assertThat(linesList.get(0)).hasSize(10);
-            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(fakeLogcat.getGeneratedLines().stream().map(s -> s + "\n").collect(Collectors.toList()));
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(fakeLogcat.getGeneratedLines());
         } finally {
             if (fakeLogcat != null) {
                 fakeLogcat.destroy();
@@ -127,7 +133,7 @@ public class LogcatProcessTest {
             watcher.run();
 
             List<String> generatedLines = fakeLogcat.getGeneratedLines();
-            List<String> generatedLineWithLF = generatedLines.stream().skip(generatedLines.size() - LogcatProcess.MAX_LINES).map(s -> s + "\n").collect(Collectors.toList());
+            List<String> generatedLineWithLF = generatedLines.subList(generatedLines.size() - LogcatProcess.MAX_LINES, generatedLines.size());
 
             List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
 
@@ -147,7 +153,7 @@ public class LogcatProcessTest {
             watcher.run();
 
             List<String> generatedLines = fakeLogcat.getGeneratedLines();
-            List<String> generatedLineWithLF = generatedLines.stream().skip(generatedLines.size() - LogcatProcess.MAX_LINES).map(s -> s + "\n").collect(Collectors.toList());
+            List<String> generatedLineWithLF = generatedLines.subList(generatedLines.size() - LogcatProcess.MAX_LINES, generatedLines.size());
 
             List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
 
@@ -177,7 +183,7 @@ public class LogcatProcessTest {
 
             Truth.assertThat(linesList).hasSize(1);
             Truth.assertThat(linesList.get(0)).hasSize(10);
-            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(fakeLogcat.getGeneratedLines().stream().map(s -> s + "\n").collect(Collectors.toList()));
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(fakeLogcat.getGeneratedLines());
 
             watcher.interrupt(); // do not throw any error
         } finally {
@@ -216,14 +222,13 @@ public class LogcatProcessTest {
             watcher.run();
 
             List<String> generatedLines = fakeLogcat.getGeneratedLines();
-            List<String> generatedLineWithLF = generatedLines.stream().map(s -> s + "\n").collect(Collectors.toList());
 
             List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
 
             // emit the first chunk but second chunk
             Truth.assertThat(linesList).hasSize(1);
             Truth.assertThat(linesList.get(0)).hasSize(LogcatProcess.MAX_LINES);
-            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(generatedLineWithLF.stream().limit(LogcatProcess.MAX_LINES).collect(Collectors.toList()));
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(generatedLines.subList(0, LogcatProcess.MAX_LINES));
         } finally {
             if (fakeLogcat != null) {
                 fakeLogcat.destroy();
@@ -247,7 +252,7 @@ public class LogcatProcessTest {
 
             Truth.assertThat(linesList).hasSize(1);
             Truth.assertThat(linesList.get(0)).hasSize(10);
-            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(fakeLogcat.getGeneratedLines().stream().map(s -> s + "\n").collect(Collectors.toList()));
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(fakeLogcat.getGeneratedLines());
 
             watcher.interrupt(); // do not throw any error
         } finally {
@@ -297,16 +302,19 @@ public class LogcatProcessTest {
     }
 
     private void destroyWorkerAfter(
-            LogcatProcess.LogcatWatcher watcher,
-            long duration,
-            TimeUnit unit
+            final LogcatProcess.LogcatWatcher watcher,
+            final long duration,
+            final TimeUnit unit
     ) {
-        Thread anotherThread = new Thread(() -> {
-            try {
-                Thread.sleep(unit.toMillis(duration));
-            } catch (InterruptedException e) {
+        Thread anotherThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(unit.toMillis(duration));
+                } catch (InterruptedException e) {
+                }
+                watcher.interrupt();
             }
-            watcher.interrupt();
         });
 
         anotherThread.start();

--- a/sdk/src/test/java/com/deploygate/sdk/LogcatProcessTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/LogcatProcessTest.java
@@ -15,7 +15,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +75,7 @@ public class LogcatProcessTest {
 
             watcher.run();
 
-            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+            List<List<String>> linesList = capture.captured.get(watcher.getBundleId());
 
             Truth.assertThat(linesList).hasSize(1);
             Truth.assertThat(linesList.get(0)).hasSize(10);
@@ -95,7 +94,7 @@ public class LogcatProcessTest {
 
             List<String> generatedLineWithLF = fakeLogcat.getGeneratedLines();
 
-            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+            List<List<String>> linesList = capture.captured.get(watcher.getBundleId());
 
             Truth.assertThat(linesList).hasSize(2);
             Truth.assertThat(linesList.get(0)).hasSize(LogcatProcess.MAX_LINES);
@@ -116,7 +115,7 @@ public class LogcatProcessTest {
 
             List<String> generatedLineWithLF = fakeLogcat.getGeneratedLines();
 
-            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+            List<List<String>> linesList = capture.captured.get(watcher.getBundleId());
 
             Truth.assertThat(linesList).hasSize(2);
             Truth.assertThat(linesList.get(0)).hasSize(LogcatProcess.MAX_LINES);
@@ -140,7 +139,7 @@ public class LogcatProcessTest {
 
             watcher.run();
 
-            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+            List<List<String>> linesList = capture.captured.get(watcher.getBundleId());
 
             Truth.assertThat(linesList).hasSize(1);
             Truth.assertThat(linesList.get(0)).hasSize(10);
@@ -160,7 +159,7 @@ public class LogcatProcessTest {
             List<String> generatedLines = fakeLogcat.getGeneratedLines();
             List<String> generatedLineWithLF = generatedLines.subList(generatedLines.size() - LogcatProcess.MAX_LINES, generatedLines.size());
 
-            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+            List<List<String>> linesList = capture.captured.get(watcher.getBundleId());
 
             Truth.assertThat(linesList).hasSize(1);
             Truth.assertThat(linesList.get(0)).hasSize(LogcatProcess.MAX_LINES);
@@ -180,7 +179,7 @@ public class LogcatProcessTest {
             List<String> generatedLines = fakeLogcat.getGeneratedLines();
             List<String> generatedLineWithLF = generatedLines.subList(generatedLines.size() - LogcatProcess.MAX_LINES, generatedLines.size());
 
-            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+            List<List<String>> linesList = capture.captured.get(watcher.getBundleId());
 
             Truth.assertThat(linesList).hasSize(1);
             Truth.assertThat(linesList.get(0)).hasSize(LogcatProcess.MAX_LINES);
@@ -204,7 +203,7 @@ public class LogcatProcessTest {
 
             watcher.run();
 
-            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+            List<List<String>> linesList = capture.captured.get(watcher.getBundleId());
 
             Truth.assertThat(linesList).hasSize(1);
             Truth.assertThat(linesList.get(0)).hasSize(10);
@@ -227,7 +226,7 @@ public class LogcatProcessTest {
 
             watcher.run();
 
-            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+            List<List<String>> linesList = capture.captured.get(watcher.getBundleId());
 
             Truth.assertThat(linesList).isNull();
         } finally {
@@ -248,7 +247,7 @@ public class LogcatProcessTest {
 
             List<String> generatedLines = fakeLogcat.getGeneratedLines();
 
-            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+            List<List<String>> linesList = capture.captured.get(watcher.getBundleId());
 
             // emit the first chunk but second chunk
             Truth.assertThat(linesList).hasSize(1);
@@ -273,7 +272,7 @@ public class LogcatProcessTest {
 
             watcher.run();
 
-            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+            List<List<String>> linesList = capture.captured.get(watcher.getBundleId());
 
             Truth.assertThat(linesList).hasSize(1);
             Truth.assertThat(linesList.get(0)).hasSize(10);
@@ -296,7 +295,7 @@ public class LogcatProcessTest {
 
             watcher.run();
 
-            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+            List<List<String>> linesList = capture.captured.get(watcher.getBundleId());
 
             Truth.assertThat(linesList).isNull();
         } finally {
@@ -315,7 +314,7 @@ public class LogcatProcessTest {
 
             watcher.run();
 
-            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+            List<List<String>> linesList = capture.captured.get(watcher.getBundleId());
 
             // no chunk should be emitted
             Truth.assertThat(linesList).isNull();
@@ -350,10 +349,10 @@ public class LogcatProcessTest {
 
         @Override
         public void emit(
-                String watchId,
+                String bundleId,
                 ArrayList<String> logcatLines
         ) {
-            List<List<String>> linesList = captured.get(watchId);
+            List<List<String>> linesList = captured.get(bundleId);
 
             if (linesList == null) {
                 linesList = new ArrayList<>();
@@ -361,7 +360,7 @@ public class LogcatProcessTest {
 
             linesList.add(logcatLines);
 
-            captured.put(watchId, linesList);
+            captured.put(bundleId, linesList);
         }
     }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/LogcatProcessTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/LogcatProcessTest.java
@@ -1,0 +1,339 @@
+package com.deploygate.sdk;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.deploygate.sdk.helper.FakeLogcat;
+import com.deploygate.sdk.internal.Factory;
+import com.google.common.truth.Truth;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@RunWith(AndroidJUnit4.class)
+public class LogcatProcessTest {
+    private FakeLogcat fakeLogcat;
+
+    @Before
+    public void before() {
+        LogcatProcess.sLogcatProcessFactory = new Factory<Process>() {
+            @Override
+            public Process create() {
+                return fakeLogcat;
+            }
+        };
+    }
+
+    @After
+    public void after() {
+        if (fakeLogcat != null) {
+            if (fakeLogcat.isAlive()) {
+                fakeLogcat.destroy();
+            }
+        }
+    }
+
+    @Test(timeout = 3000L)
+    public void nonOneShot_emits_multiple_log_chunks() {
+        CaptureCallback capture = new CaptureCallback();
+
+        try {
+            fakeLogcat = new FakeLogcat(10);
+            LogcatProcess.LogcatWatcher watcher = new LogcatProcess.LogcatWatcher(false, capture);
+
+            watcher.run();
+
+            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+
+            Truth.assertThat(linesList).hasSize(1);
+            Truth.assertThat(linesList.get(0)).hasSize(10);
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(fakeLogcat.getGeneratedLines().stream().map(s -> s + "\n").collect(Collectors.toList()));
+        } finally {
+            if (fakeLogcat != null) {
+                fakeLogcat.destroy();
+            }
+        }
+
+        try {
+            fakeLogcat = new FakeLogcat(501);
+            LogcatProcess.LogcatWatcher watcher = new LogcatProcess.LogcatWatcher(false, capture);
+
+            watcher.run();
+
+            List<String> generatedLineWithLF = fakeLogcat.getGeneratedLines().stream().map(s -> s + "\n").collect(Collectors.toList());
+
+            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+
+            Truth.assertThat(linesList).hasSize(2);
+            Truth.assertThat(linesList.get(0)).hasSize(LogcatProcess.MAX_LINES);
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(generatedLineWithLF.stream().limit(LogcatProcess.MAX_LINES).collect(Collectors.toList()));
+            Truth.assertThat(linesList.get(1)).hasSize(1);
+            Truth.assertThat(linesList.get(1)).containsExactlyElementsIn(generatedLineWithLF.stream().skip(LogcatProcess.MAX_LINES).collect(Collectors.toList()));
+        } finally {
+            if (fakeLogcat != null) {
+                fakeLogcat.destroy();
+            }
+        }
+
+        try {
+            fakeLogcat = new FakeLogcat(1000);
+            LogcatProcess.LogcatWatcher watcher = new LogcatProcess.LogcatWatcher(false, capture);
+
+            watcher.run();
+
+            List<String> generatedLineWithLF = fakeLogcat.getGeneratedLines().stream().map(s -> s + "\n").collect(Collectors.toList());
+
+            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+
+            Truth.assertThat(linesList).hasSize(2);
+            Truth.assertThat(linesList.get(0)).hasSize(LogcatProcess.MAX_LINES);
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(generatedLineWithLF.stream().limit(LogcatProcess.MAX_LINES).collect(Collectors.toList()));
+            Truth.assertThat(linesList.get(1)).hasSize(LogcatProcess.MAX_LINES);
+            Truth.assertThat(linesList.get(1)).containsExactlyElementsIn(generatedLineWithLF.stream().skip(LogcatProcess.MAX_LINES).limit(LogcatProcess.MAX_LINES).collect(Collectors.toList()));
+        } finally {
+            if (fakeLogcat != null) {
+                fakeLogcat.destroy();
+            }
+        }
+    }
+
+    @Test(timeout = 3000L)
+    public void OneShot_emits_single_log_chunk() {
+        CaptureCallback capture = new CaptureCallback();
+
+        try {
+            fakeLogcat = new FakeLogcat(10);
+            LogcatProcess.LogcatWatcher watcher = new LogcatProcess.LogcatWatcher(true, capture);
+
+            watcher.run();
+
+            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+
+            Truth.assertThat(linesList).hasSize(1);
+            Truth.assertThat(linesList.get(0)).hasSize(10);
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(fakeLogcat.getGeneratedLines().stream().map(s -> s + "\n").collect(Collectors.toList()));
+        } finally {
+            if (fakeLogcat != null) {
+                fakeLogcat.destroy();
+            }
+        }
+
+        try {
+            fakeLogcat = new FakeLogcat(501);
+            LogcatProcess.LogcatWatcher watcher = new LogcatProcess.LogcatWatcher(true, capture);
+
+            watcher.run();
+
+            List<String> generatedLines = fakeLogcat.getGeneratedLines();
+            List<String> generatedLineWithLF = generatedLines.stream().skip(generatedLines.size() - LogcatProcess.MAX_LINES).map(s -> s + "\n").collect(Collectors.toList());
+
+            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+
+            Truth.assertThat(linesList).hasSize(1);
+            Truth.assertThat(linesList.get(0)).hasSize(LogcatProcess.MAX_LINES);
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(generatedLineWithLF);
+        } finally {
+            if (fakeLogcat != null) {
+                fakeLogcat.destroy();
+            }
+        }
+
+        try {
+            fakeLogcat = new FakeLogcat(1000);
+            LogcatProcess.LogcatWatcher watcher = new LogcatProcess.LogcatWatcher(true, capture);
+
+            watcher.run();
+
+            List<String> generatedLines = fakeLogcat.getGeneratedLines();
+            List<String> generatedLineWithLF = generatedLines.stream().skip(generatedLines.size() - LogcatProcess.MAX_LINES).map(s -> s + "\n").collect(Collectors.toList());
+
+            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+
+            Truth.assertThat(linesList).hasSize(1);
+            Truth.assertThat(linesList.get(0)).hasSize(LogcatProcess.MAX_LINES);
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(generatedLineWithLF);
+        } finally {
+            if (fakeLogcat != null) {
+                fakeLogcat.destroy();
+            }
+        }
+    }
+
+    @Test(timeout = 3000L)
+    public void nonOneShot_interrupt_stops_later_emits() {
+        CaptureCallback capture = new CaptureCallback();
+
+        try {
+            // call the method for the finished process
+
+            fakeLogcat = new FakeLogcat(10);
+            LogcatProcess.LogcatWatcher watcher = new LogcatProcess.LogcatWatcher(false, capture);
+
+            watcher.run();
+
+            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+
+            Truth.assertThat(linesList).hasSize(1);
+            Truth.assertThat(linesList.get(0)).hasSize(10);
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(fakeLogcat.getGeneratedLines().stream().map(s -> s + "\n").collect(Collectors.toList()));
+
+            watcher.interrupt(); // do not throw any error
+        } finally {
+            if (fakeLogcat != null) {
+                fakeLogcat.destroy();
+            }
+        }
+
+        try {
+            // call the method for the finished process
+
+            fakeLogcat = new FakeLogcat(20, 10);
+            LogcatProcess.LogcatWatcher watcher = new LogcatProcess.LogcatWatcher(false, capture);
+
+            destroyWorkerAfter(watcher, 300, TimeUnit.MILLISECONDS);
+
+            watcher.run();
+
+            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+
+            Truth.assertThat(linesList).isNull();
+        } finally {
+            if (fakeLogcat != null) {
+                fakeLogcat.destroy();
+            }
+        }
+
+        try {
+            // call the method for the finished process
+
+            fakeLogcat = new FakeLogcat(550, 549);
+            LogcatProcess.LogcatWatcher watcher = new LogcatProcess.LogcatWatcher(false, capture);
+
+            destroyWorkerAfter(watcher, 500, TimeUnit.MILLISECONDS);
+
+            watcher.run();
+
+            List<String> generatedLines = fakeLogcat.getGeneratedLines();
+            List<String> generatedLineWithLF = generatedLines.stream().map(s -> s + "\n").collect(Collectors.toList());
+
+            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+
+            // emit only once due to interrupted
+            Truth.assertThat(linesList).hasSize(1);
+            Truth.assertThat(linesList.get(0)).hasSize(LogcatProcess.MAX_LINES);
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(generatedLineWithLF.stream().limit(LogcatProcess.MAX_LINES).collect(Collectors.toList()));
+        } finally {
+            if (fakeLogcat != null) {
+                fakeLogcat.destroy();
+            }
+        }
+    }
+
+    @Test(timeout = 3000L)
+    public void OneShot_interrupt_stops_emitting_logs() {
+        CaptureCallback capture = new CaptureCallback();
+
+        try {
+            // call the method for the finished process
+
+            fakeLogcat = new FakeLogcat(10);
+            LogcatProcess.LogcatWatcher watcher = new LogcatProcess.LogcatWatcher(true, capture);
+
+            watcher.run();
+
+            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+
+            Truth.assertThat(linesList).hasSize(1);
+            Truth.assertThat(linesList.get(0)).hasSize(10);
+            Truth.assertThat(linesList.get(0)).containsExactlyElementsIn(fakeLogcat.getGeneratedLines().stream().map(s -> s + "\n").collect(Collectors.toList()));
+
+            watcher.interrupt(); // do not throw any error
+        } finally {
+            if (fakeLogcat != null) {
+                fakeLogcat.destroy();
+            }
+        }
+
+        try {
+            // call the method for the finished process
+
+            fakeLogcat = new FakeLogcat(20, 10);
+            LogcatProcess.LogcatWatcher watcher = new LogcatProcess.LogcatWatcher(true, capture);
+
+            destroyWorkerAfter(watcher, 300, TimeUnit.MILLISECONDS);
+
+            watcher.run();
+
+            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+
+            Truth.assertThat(linesList).isNull();
+        } finally {
+            if (fakeLogcat != null) {
+                fakeLogcat.destroy();
+            }
+        }
+
+        try {
+            // call the method for the finished process
+
+            fakeLogcat = new FakeLogcat(520, 502);
+            LogcatProcess.LogcatWatcher watcher = new LogcatProcess.LogcatWatcher(true, capture);
+
+            destroyWorkerAfter(watcher, 300, TimeUnit.MILLISECONDS);
+
+            watcher.run();
+
+            List<List<String>> linesList = capture.captured.get(watcher.getWatchId());
+
+            Truth.assertThat(linesList).isNull();
+        } finally {
+            if (fakeLogcat != null) {
+                fakeLogcat.destroy();
+            }
+        }
+    }
+
+    private void destroyWorkerAfter(
+            LogcatProcess.LogcatWatcher watcher,
+            long duration,
+            TimeUnit unit
+    ) {
+        Thread anotherThread = new Thread(() -> {
+            try {
+                Thread.sleep(unit.toMillis(duration));
+            } catch (InterruptedException e) {
+            }
+            watcher.interrupt();
+        });
+
+        anotherThread.start();
+    }
+
+    private static class CaptureCallback implements LogcatProcess.Callback {
+        private final Map<String, List<List<String>>> captured = new HashMap<>();
+
+        @Override
+        public void emit(
+                String watchId,
+                ArrayList<String> logcatLines
+        ) {
+            List<List<String>> linesList = captured.get(watchId);
+
+            if (linesList == null) {
+                linesList = new ArrayList<>();
+            }
+
+            linesList.add(logcatLines);
+
+            captured.put(watchId, linesList);
+        }
+    }
+}

--- a/sdk/src/test/java/com/deploygate/sdk/SendLogcatRequestTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/SendLogcatRequestTest.java
@@ -1,0 +1,154 @@
+package com.deploygate.sdk;
+
+import android.os.Bundle;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.deploygate.sdk.truth.BundleSubject;
+import com.google.common.truth.Fact;
+import com.google.common.truth.FailureMetadata;
+import com.google.common.truth.Subject;
+import com.google.common.truth.Truth;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+@RunWith(AndroidJUnit4.class)
+public class SendLogcatRequestTest {
+
+    @Test
+    public void toExtras_must_be_valid_format() {
+        SendLogcatRequest request = new SendLogcatRequest("watchId", new ArrayList<>(Arrays.asList("1", "2")));
+
+        BundleSubject.assertThat(request.toExtras()).isEqualTo(createLogExtra("watchId", new ArrayList<>(Arrays.asList("1", "2"))));
+    }
+
+    @Test
+    public void splitInto_create_n_sublist() {
+        SendLogcatRequest request = new SendLogcatRequest("watchId", arrayListOf(0, 10));
+
+        List<SendLogcatRequest> singleRequests = request.splitInto(1);
+
+        Truth.assertThat(singleRequests).hasSize(1);
+        SendLogcatRequestSubject.assertThat(singleRequests.get(0)).isEqualTo(request);
+
+        List<SendLogcatRequest> twoRequests = request.splitInto(2);
+        Truth.assertThat(twoRequests).hasSize(2);
+        SendLogcatRequestSubject.assertThat(twoRequests.get(0)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(0, 5)));
+        SendLogcatRequestSubject.assertThat(twoRequests.get(1)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(5, 5)));
+
+        List<SendLogcatRequest> threeRequests = request.splitInto(3);
+        Truth.assertThat(threeRequests).hasSize(3);
+        SendLogcatRequestSubject.assertThat(threeRequests.get(0)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(0, 3)));
+        SendLogcatRequestSubject.assertThat(threeRequests.get(1)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(3, 3)));
+        SendLogcatRequestSubject.assertThat(threeRequests.get(2)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(6, 4)));
+
+        List<SendLogcatRequest> nineRequests = request.splitInto(9);
+        Truth.assertThat(nineRequests).hasSize(9);
+        SendLogcatRequestSubject.assertThat(nineRequests.get(0)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(0, 1)));
+        SendLogcatRequestSubject.assertThat(nineRequests.get(1)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(1, 1)));
+        SendLogcatRequestSubject.assertThat(nineRequests.get(2)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(2, 1)));
+        SendLogcatRequestSubject.assertThat(nineRequests.get(3)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(3, 1)));
+        SendLogcatRequestSubject.assertThat(nineRequests.get(4)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(4, 1)));
+        SendLogcatRequestSubject.assertThat(nineRequests.get(5)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(5, 1)));
+        SendLogcatRequestSubject.assertThat(nineRequests.get(6)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(6, 1)));
+        SendLogcatRequestSubject.assertThat(nineRequests.get(7)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(7, 1)));
+        SendLogcatRequestSubject.assertThat(nineRequests.get(8)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(8, 2)));
+
+        List<SendLogcatRequest> overSplitRequests = request.splitInto(11);
+        Truth.assertThat(overSplitRequests).hasSize(10);
+        SendLogcatRequestSubject.assertThat(overSplitRequests.get(0)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(0, 1)));
+        SendLogcatRequestSubject.assertThat(overSplitRequests.get(1)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(1, 1)));
+        SendLogcatRequestSubject.assertThat(overSplitRequests.get(2)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(2, 1)));
+        SendLogcatRequestSubject.assertThat(overSplitRequests.get(3)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(3, 1)));
+        SendLogcatRequestSubject.assertThat(overSplitRequests.get(4)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(4, 1)));
+        SendLogcatRequestSubject.assertThat(overSplitRequests.get(5)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(5, 1)));
+        SendLogcatRequestSubject.assertThat(overSplitRequests.get(6)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(6, 1)));
+        SendLogcatRequestSubject.assertThat(overSplitRequests.get(7)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(7, 1)));
+        SendLogcatRequestSubject.assertThat(overSplitRequests.get(8)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(8, 1)));
+        SendLogcatRequestSubject.assertThat(overSplitRequests.get(9)).isEqualTo(new SendLogcatRequest(request.watchId, arrayListOf(9, 1)));
+    }
+
+    private static Bundle createLogExtra(
+            String watchId,
+            ArrayList<String> lines
+    ) {
+        Bundle bundle = new Bundle();
+        bundle.putString("logId", watchId);
+        bundle.putStringArrayList("log", lines);
+        return bundle;
+    }
+
+    private static ArrayList<String> arrayListOf(int startInclusive, int count) {
+        return IntStream.range(startInclusive, startInclusive + count).mapToObj(String::valueOf).collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    private static class SendLogcatRequestSubject extends Subject {
+        public static Factory<SendLogcatRequestSubject, SendLogcatRequest> sendLogcatRequests() {
+            return new Factory<SendLogcatRequestSubject, SendLogcatRequest>() {
+                @Override
+                public SendLogcatRequestSubject createSubject(
+                        FailureMetadata metadata,
+                        SendLogcatRequest actual
+                ) {
+                    return new SendLogcatRequestSubject(metadata, actual);
+                }
+            };
+        }
+
+        public static SendLogcatRequestSubject assertThat(SendLogcatRequest actual) {
+            return assertAbout(sendLogcatRequests()).that(actual);
+        }
+
+        private final SendLogcatRequest actual;
+
+        protected SendLogcatRequestSubject(
+                FailureMetadata metadata,
+                SendLogcatRequest actual
+        ) {
+            super(metadata, actual);
+            this.actual = actual;
+        }
+
+        @Override
+        public void isEqualTo(Object expected) {
+            Truth.assertThat(expected).isInstanceOf(SendLogcatRequest.class);
+
+            SendLogcatRequest request = (SendLogcatRequest) expected;
+
+            if (!actual.watchId.equals(request.watchId) || actual.lines.size() != request.lines.size()) {
+                failWithActual(Fact.simpleFact(String.format(Locale.US, "%s is expected to %s", toString(request), toString(actual))));
+                return;
+            }
+
+            for (int i = 0; i < request.lines.size(); i++) {
+                if (!request.lines.get(i).equals(actual.lines.get(i))) {
+                    failWithActual(Fact.simpleFact(String.format(Locale.US, "%s is expected to %s", toString(request), toString(actual))));
+                    return;
+                }
+            }
+        }
+
+        private static String toString(SendLogcatRequest request) {
+            StringBuilder builder = new StringBuilder();
+            builder.append("{ ");
+            builder.append("watchId=");
+            builder.append(request.watchId);
+            builder.append(", lines=[");
+            builder.append(String.join(", ", request.lines));
+            builder.append("]");
+            builder.append(" }");
+            return builder.toString();
+        }
+    }
+
+}

--- a/sdk/src/test/java/com/deploygate/sdk/SendLogcatRequestTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/SendLogcatRequestTest.java
@@ -10,6 +10,7 @@ import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.Subject;
 import com.google.common.truth.Truth;
 
+import org.checkerframework.checker.units.qual.A;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -89,7 +90,13 @@ public class SendLogcatRequestTest {
     }
 
     private static ArrayList<String> arrayListOf(int startInclusive, int count) {
-        return IntStream.range(startInclusive, startInclusive + count).mapToObj(String::valueOf).collect(Collectors.toCollection(ArrayList::new));
+        ArrayList<String> list = new ArrayList<>();
+
+        for (int i = startInclusive, max = startInclusive + count; i < max; i++) {
+            list.add(String.valueOf(i));
+        }
+
+        return list;
     }
 
     private static class SendLogcatRequestSubject extends Subject {

--- a/sdk/src/test/java/com/deploygate/sdk/helper/FakeLogcat.java
+++ b/sdk/src/test/java/com/deploygate/sdk/helper/FakeLogcat.java
@@ -1,0 +1,147 @@
+package com.deploygate.sdk.helper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+public class FakeLogcat extends Process {
+    private final int suspendAtLine;
+    private final List<String> generatedLines;
+    private final InputStream in;
+    private boolean isDestroyed;
+
+    public FakeLogcat(
+            int lines
+    ) {
+        this(lines, -1);
+    }
+
+    public FakeLogcat(
+            int lines,
+            int suspendAtLine
+    ) {
+        if (lines < suspendAtLine) {
+            throw new IllegalArgumentException(String.format(Locale.US, "suspendAtLine (%d) must be less than lines (%d)", suspendAtLine, lines));
+        }
+
+        this.suspendAtLine = suspendAtLine;
+        this.generatedLines = new ArrayList<>();
+        this.in = new InputStream() {
+            private int lineLength = UUID.randomUUID().toString().length();
+            private int available = lineLength * lines + lines - 1;
+
+            private String currentLine;
+            private int index = 0;
+
+            @Override
+            public int read() throws IOException {
+                if (isDestroyed) {
+                    throw new IOException("already destroyed");
+                }
+
+                if (currentLine == null) {
+                    index = 0;
+                    currentLine = UUID.randomUUID().toString();
+                    generatedLines.add(currentLine);
+                }
+
+                if (suspendAtLine > 0 && generatedLines.size() >= suspendAtLine) {
+                    return 0;
+                }
+
+                final int read;
+
+                if (currentLine.length() <= index) {
+                    if (lines == generatedLines.size()) {
+                        return -1;
+                    }
+
+                    index = 0;
+                    currentLine = UUID.randomUUID().toString();
+                    generatedLines.add(currentLine);
+                    read = '\n';
+                } else {
+                    read = currentLine.charAt(index++);
+                }
+
+                if (available > 0) {
+                    available -= read;
+                }
+
+                return read;
+            }
+
+            @Override
+            public int available() throws IOException {
+                if (isDestroyed) {
+                    throw new IOException("already destroyed");
+                }
+
+                return Math.max(available, 0);
+            }
+        };
+    }
+
+    public List<String> getGeneratedLines() {
+        return Collections.unmodifiableList(generatedLines);
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        throw new RuntimeException("output stream is not supported");
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        if (isDestroyed) {
+            throw new IllegalStateException("process is already destroyed");
+        }
+
+        return in;
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+        throw new RuntimeException("output stream is not supported");
+    }
+
+    @Override
+    public int waitFor() throws InterruptedException {
+        return 0;
+    }
+
+    @Override
+    public int exitValue() {
+        if (!isDestroyed) {
+            try {
+                if (in.available() == 0) {
+                    return 0;
+                }
+            } catch (IOException ignore) {
+            }
+
+            throw new IllegalThreadStateException("not yet destroyed");
+        }
+
+        return 0;
+    }
+
+    @Override
+    public void destroy() {
+        if (isDestroyed) {
+            return;
+        }
+
+        isDestroyed = true;
+
+        try {
+            in.close();
+        } catch (IOException ignore) {
+        }
+    }
+}

--- a/sdk/src/test/java/com/deploygate/sdk/helper/FakeLogcat.java
+++ b/sdk/src/test/java/com/deploygate/sdk/helper/FakeLogcat.java
@@ -22,8 +22,8 @@ public class FakeLogcat extends Process {
     }
 
     public FakeLogcat(
-            int lines,
-            int suspendAtLine
+            final int lines,
+            final int suspendAtLine
     ) {
         if (lines < suspendAtLine) {
             throw new IllegalArgumentException(String.format(Locale.US, "suspendAtLine (%d) must be less than lines (%d)", suspendAtLine, lines));
@@ -47,7 +47,7 @@ public class FakeLogcat extends Process {
                 if (currentLine == null) {
                     index = 0;
                     currentLine = UUID.randomUUID().toString();
-                    generatedLines.add(currentLine);
+                    generatedLines.add(currentLine + '\n');
                 }
 
                 if (suspendAtLine > 0 && generatedLines.size() >= suspendAtLine) {
@@ -63,7 +63,7 @@ public class FakeLogcat extends Process {
 
                     index = 0;
                     currentLine = UUID.randomUUID().toString();
-                    generatedLines.add(currentLine);
+                    generatedLines.add(currentLine + '\n');
                     read = '\n';
                 } else {
                     read = currentLine.charAt(index++);


### PR DESCRIPTION
This changeset serializes the instruction for sending Logcat data to the remove service. 

ref: https://github.com/DeployGate/deploygate-android-sdk/issues/48

## Buffering Overview

We should buffer the instruction for sending one chunk of lines to the remote service but not for starting Logcat process because Logcat is launchable regardless of the client app's availability.

```mermaid
sequenceDiagram
    participant Logcat
    participant Reader (SDK)
    participant Serializer (SDK)
    participant ClientApp

Reader (SDK)->>Logcat: Create a process
Logcat->>Logcat: Generate the bundle id

loop Streaming
    Logcat->>Reader (SDK): Read and pack lines as a chunk
end

    Reader (SDK)-->>Serializer (SDK): Enqueue the send-instruction on every chunk
    Serializer (SDK)->>Serializer (SDK): Serialize and process the instructions
    Serializer (SDK)->>ClientApp: Emit chunks one by one
```

In this case, the bundle id is the one-to-one relation with the process id of Logcat.

## Retry

Buffering Logcat requires the special retry mechanism that splits larger AIDL transaction into smaller serialized transactions.

## Todo

Refactor these redundant code.

- https://github.com/DeployGate/deploygate-android-sdk/pull/58/files#diff-cc72d904aba4511de76932694c6d4d6cdba24e872a38863bda0589525fb0ecb5R308
- https://github.com/DeployGate/deploygate-android-sdk/pull/58/files#diff-cc72d904aba4511de76932694c6d4d6cdba24e872a38863bda0589525fb0ecb5R236