### PR TITLE
Send the unique id to identify the event (data)

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -8,6 +8,7 @@ android {
 
 dependencies {
     testImplementation 'org.mockito:mockito-core:4.4.0'
+    testImplementation 'org.mockito:mockito-inline:4.4.0'
 }
 
 ext {

--- a/sdk/src/main/java/com/deploygate/sdk/CustomLog.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomLog.java
@@ -6,6 +6,7 @@ import android.os.SystemClock;
 import com.deploygate.service.DeployGateEvent;
 
 class CustomLog {
+    public final String uid;
     public final String type;
     public final String body;
     private final long elapsedTime;
@@ -17,6 +18,7 @@ class CustomLog {
     ) {
         this.type = type;
         this.body = body;
+        this.uid = UniqueId.generate();
         this.elapsedTime = SystemClock.elapsedRealtime();
         this.retryCount = 0;
     }
@@ -33,6 +35,7 @@ class CustomLog {
      */
     Bundle toExtras() {
         Bundle extras = new Bundle();
+        extras.putSerializable(DeployGateEvent.EXTRA_UID, uid);
         extras.putSerializable(DeployGateEvent.EXTRA_LOG, body);
         extras.putSerializable(DeployGateEvent.EXTRA_LOG_TYPE, type);
         extras.putLong(DeployGateEvent.EXTRA_BUFFERED_AT_IN_MILLI_SECONDS, elapsedTime);

--- a/sdk/src/main/java/com/deploygate/sdk/CustomLogInstructionSerializer.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomLogInstructionSerializer.java
@@ -90,14 +90,11 @@ class CustomLogInstructionSerializer {
     /**
      * Request sending custom logs to DeployGate client service. All requests will be scheduled to an exclusive thread.
      *
-     * @param type
-     *         custom log type
-     * @param body
-     *         custom log body
+     * @param log
+     *         a custum log to send
      */
     public final synchronized void requestSendingLog(
-            String type,
-            String body
+            CustomLog log
     ) {
         if (isDisabled) {
             return;
@@ -105,7 +102,6 @@ class CustomLogInstructionSerializer {
 
         ensureHandlerInitialized();
 
-        CustomLog log = new CustomLog(type, body);
         handler.enqueueAddNewLogInstruction(log);
     }
 

--- a/sdk/src/main/java/com/deploygate/sdk/CustomLogInstructionSerializer.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomLogInstructionSerializer.java
@@ -145,6 +145,14 @@ class CustomLogInstructionSerializer {
         return handler != null;
     }
 
+    boolean hasAnyMessage() {
+        if (handler == null) {
+            return false;
+        }
+
+        return handler.hasMessages(CustomLogHandler.WHAT_SEND_LOGS) || handler.hasMessages(CustomLogHandler.WHAT_ADD_NEW_LOG);
+    }
+
     int getPendingCount() {
         if (handler == null) {
             return 0;

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -1096,7 +1096,7 @@ public class DeployGate {
             String type,
             String body
     ) {
-        mCustomLogInstructionSerializer.requestSendingLog(type, body);
+        mCustomLogInstructionSerializer.requestSendingLog(new CustomLog(type, body));
     }
 
     /**

--- a/sdk/src/main/java/com/deploygate/sdk/UniqueId.java
+++ b/sdk/src/main/java/com/deploygate/sdk/UniqueId.java
@@ -1,0 +1,9 @@
+package com.deploygate.sdk;
+
+import java.util.UUID;
+
+class UniqueId {
+    static String generate() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -31,6 +31,7 @@ public interface DeployGateEvent {
     public static final String EXTRA_LOG = "log";
     public static final String EXTRA_LOG_TYPE = "logType";
     public static final String EXTRA_BUFFERED_AT_IN_MILLI_SECONDS = "bufferedAt";
+    public static final String EXTRA_UID = "uid";
 
     /**
      * this key shouldn't be used

--- a/sdk/src/test/java/com/deploygate/sdk/CustomLogInstructionSerializerTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CustomLogInstructionSerializerTest.java
@@ -177,6 +177,7 @@ public class CustomLogInstructionSerializerTest {
         Shadows.shadowOf(customLogInstructionSerializer.getLooper()).idle();
 
         Truth.assertThat(customLogInstructionSerializer.getPendingCount()).isEqualTo(30);
+        Truth.assertThat(customLogInstructionSerializer.hasAnyMessage()).isFalse();
     }
 
     @Test(timeout = 3000L)
@@ -191,7 +192,6 @@ public class CustomLogInstructionSerializerTest {
         }
 
         Truth.assertThat(customLogInstructionSerializer.hasHandlerInitialized()).isFalse();
-        Truth.assertThat(customLogInstructionSerializer.getPendingCount()).isEqualTo(0);
 
         // Even if a service connection is established, this does nothing.
         customLogInstructionSerializer.connect(service);
@@ -203,6 +203,7 @@ public class CustomLogInstructionSerializerTest {
         Shadows.shadowOf(customLogInstructionSerializer.getLooper()).idle();
 
         Truth.assertThat(customLogInstructionSerializer.getPendingCount()).isEqualTo(0);
+        Truth.assertThat(customLogInstructionSerializer.hasAnyMessage()).isFalse();
     }
 
     @Test(timeout = 3000L)
@@ -221,11 +222,10 @@ public class CustomLogInstructionSerializerTest {
 
         Shadows.shadowOf(customLogInstructionSerializer.getLooper()).idle();
 
-        while (customLogInstructionSerializer.getPendingCount() > 0) {
+        while (customLogInstructionSerializer.hasAnyMessage() || customLogInstructionSerializer.getPendingCount() > 0) {
             Shadows.shadowOf(customLogInstructionSerializer.getLooper()).idleFor(100, TimeUnit.MILLISECONDS);
         }
 
-        Truth.assertThat(customLogInstructionSerializer.getPendingCount()).isEqualTo(0);
         Mockito.verify(service, times((CustomLogInstructionSerializer.MAX_RETRY_COUNT + 1) * 10)).sendEvent(eq(PACKAGE_NAME), eq(DeployGateEvent.ACTION_SEND_CUSTOM_LOG), any(Bundle.class));
     }
 


### PR DESCRIPTION
As for the current events, the consistency is guaranteed but the further events may not have. So, the data provider should generate the unique id for each events to keep data inconsistency between the single AIDL transaction. 

fix: https://github.com/DeployGate/deploygate-android-sdk/issues/57