### PR TITLE
Use metadata to get static values

### DIFF
--- a/sdk.build.gradle
+++ b/sdk.build.gradle
@@ -30,6 +30,9 @@ android {
     }
 
     testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
         unitTests.all {
             jvmArgs "-Xmx1g"
         }

--- a/sdk.build.gradle
+++ b/sdk.build.gradle
@@ -11,6 +11,7 @@ android {
         targetSdkVersion 29
         versionCode 1
         versionName project.version
+        manifestPlaceholders = [sdkVersion:"4"]
     }
 
     buildTypes {

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -8,6 +8,11 @@
             android:name=".DeployGateProvider"
             android:exported="false"
             />
+
+        <meta-data
+            android:name="com.deploygate.sdk.version"
+            android:value="${sdkVersion}"
+            />
     </application>
     <queries>
         <package android:name="com.deploygate" />

--- a/sdk/src/main/java/com/deploygate/sdk/Compatibility.java
+++ b/sdk/src/main/java/com/deploygate/sdk/Compatibility.java
@@ -1,14 +1,27 @@
 package com.deploygate.sdk;
 
 enum Compatibility {
-    UPDATE_MESSAGE_OF_BUILD(0b1),
-    SERIALIZED_EXCEPTION(0b10),
-    LOGCAT_BUNDLE(0b100);
+    UPDATE_MESSAGE_OF_BUILD(1),
+    SERIALIZED_EXCEPTION(1 << 1),
+    LOGCAT_BUNDLE(1 << 2);
 
     final int bitMask;
 
     Compatibility(int bitMask) {
         this.bitMask = bitMask;
+    }
+
+    /**
+     * @return sum of all bits
+     */
+    static int all() {
+        int bit = 0;
+
+        for (Compatibility compatibility : Compatibility.values()) {
+            bit |= compatibility.bitMask;
+        }
+
+        return bit;
     }
 
     /**

--- a/sdk/src/main/java/com/deploygate/sdk/Compatibility.java
+++ b/sdk/src/main/java/com/deploygate/sdk/Compatibility.java
@@ -1,30 +1,23 @@
 package com.deploygate.sdk;
 
-final class Compatibility {
+enum Compatibility {
+    UPDATE_MESSAGE_OF_BUILD(0b1),
+    SERIALIZED_EXCEPTION(0b10),
+    LOGCAT_BUNDLE(0b100);
+
+    final int bitMask;
+
+    Compatibility(int bitMask) {
+        this.bitMask = bitMask;
+    }
+
     /**
-     * All values must be *inclusive*. {@link Integer#MAX_VALUE} means the version is not fixed yet.
+     * All values must be *inclusive*.
+     * Use manifest metadata to know if a feature is supported on the client app.
      */
+    @Deprecated
     static final class ClientVersion {
         static final int SUPPORT_UPDATE_MESSAGE_OF_BUILD = 39;
         static final int SUPPORT_SERIALIZED_EXCEPTION = 42;
-        static final int SUPPORT_LOGCAT_BUNDLE = Integer.MAX_VALUE;
-    }
-
-    static boolean isUpdateMessageOfBuildSupported() {
-        return DeployGate.getDeployGateVersionCode() >= ClientVersion.SUPPORT_UPDATE_MESSAGE_OF_BUILD;
-    }
-
-    /**
-     * older clients crash due to ClassNotFound if SDK sends custom exceptions.
-     */
-    static boolean isSerializedExceptionSupported() {
-        return DeployGate.getDeployGateVersionCode() >= ClientVersion.SUPPORT_SERIALIZED_EXCEPTION;
-    }
-
-    /**
-     * older clients emits only the single set of lines.
-     */
-    static boolean isLogcatBundleSupported() {
-        return DeployGate.getDeployGateVersionCode() >= ClientVersion.SUPPORT_LOGCAT_BUNDLE;
     }
 }

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGateClient.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGateClient.java
@@ -1,0 +1,138 @@
+package com.deploygate.sdk;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.Signature;
+import android.content.pm.SigningInfo;
+import android.os.Build;
+
+import com.deploygate.sdk.internal.Logger;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+class DeployGateClient {
+    private static final String[] FINGERPRINTS = new String[]{
+            // deploygate release
+            "2f97f647645cb762bf5fc1445599a954e6ad76e7",
+            // mba debug
+            "c1f285f69cc02a397135ed182aa79af53d5d20a1"
+    };
+
+    public final long versionCode;
+    public final boolean isInstalled;
+    private final long featuresFlag;
+
+    @SuppressLint("PackageManagerGetSignatures")
+    DeployGateClient(
+            Context context,
+            String packageName
+    ) {
+        PackageInfo info = null;
+        int flag = PackageManager.GET_META_DATA;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            flag |= PackageManager.GET_SIGNING_CERTIFICATES;
+        } else {
+            flag |= PackageManager.GET_SIGNATURES;
+        }
+
+        try {
+            info = context.getPackageManager().getPackageInfo(packageName, flag);
+        } catch (PackageManager.NameNotFoundException e) {
+            Logger.w("deploygate app is not found");
+        }
+
+        if (info != null) {
+            this.isInstalled = checkSignature(info);
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                this.versionCode = info.getLongVersionCode();
+            } else {
+                this.versionCode = info.versionCode;
+            }
+
+            this.featuresFlag = info.applicationInfo.metaData.getLong("com.deploygate.features", 0);
+        } else {
+            this.isInstalled = false;
+            this.versionCode = 0;
+            this.featuresFlag = 0;
+        }
+    }
+
+    boolean isSupported(Compatibility compatibility) {
+        if (featuresFlag <= 0) {
+            switch (compatibility) {
+                case UPDATE_MESSAGE_OF_BUILD:
+                    return versionCode >= Compatibility.ClientVersion.SUPPORT_UPDATE_MESSAGE_OF_BUILD;
+                case SERIALIZED_EXCEPTION:
+                    return versionCode >= Compatibility.ClientVersion.SUPPORT_SERIALIZED_EXCEPTION;
+                default:
+                    return false;
+            }
+        }
+
+        return (featuresFlag & compatibility.bitMask) > 0;
+    }
+
+    /**
+     * Check if the whitelist contains at least one of signing information.
+     * Returning *true* may contain false-positive API 19 or lower. ref: FakeID
+     *
+     * @param info
+     *         com.deploygate's package info
+     *
+     * @return true if at least one of signature is in the whitelist, otherwise false.
+     */
+    private static boolean checkSignature(PackageInfo info) {
+        final MessageDigest md;
+
+        try {
+            md = MessageDigest.getInstance("SHA1");
+        } catch (NoSuchAlgorithmException e) {
+            Logger.e("SHA1 is not supported on this platform?", e);
+            return false;
+        }
+
+        final Signature[] signatures;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            SigningInfo signingInfo = info.signingInfo;
+
+            if (signingInfo == null) {
+                return false;
+            }
+
+            if (signingInfo.hasMultipleSigners()) {
+                signatures = signingInfo.getApkContentsSigners();
+            } else {
+                signatures = signingInfo.getSigningCertificateHistory();
+            }
+        } else {
+            signatures = info.signatures;
+        }
+
+        if (signatures == null) {
+            return false;
+        }
+
+        for (Signature signature : signatures) {
+            byte[] digest = md.digest(signature.toByteArray());
+            StringBuilder result = new StringBuilder(40);
+            for (byte b : digest) {
+                result.append(Integer.toString((b & 0xff) + 0x100, 16).substring(1));
+            }
+            String hex = result.toString();
+
+            for (final String fingerprint : FINGERPRINTS) {
+                if (fingerprint.equals(hex)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/sdk/src/main/java/com/deploygate/sdk/HostApp.java
+++ b/sdk/src/main/java/com/deploygate/sdk/HostApp.java
@@ -1,0 +1,48 @@
+package com.deploygate.sdk;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
+
+import com.deploygate.sdk.internal.Logger;
+
+class HostApp {
+    public final String packageName;
+    public final boolean canUseLogcat;
+    public final boolean debuggable;
+    public final int sdkVersion;
+
+    HostApp(
+            Context context
+    ) {
+        this.packageName = context.getPackageName();
+        PackageManager pm = context.getPackageManager();
+
+        ApplicationInfo info = null;
+
+        try {
+            info = pm.getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+        } catch (PackageManager.NameNotFoundException e) {
+            Logger.w(e, "unexpected code");
+        }
+
+        if (info == null) {
+            this.debuggable = false;
+            this.canUseLogcat = false;
+            this.sdkVersion = 0;
+            return;
+        }
+
+        this.debuggable = (info.flags & ApplicationInfo.FLAG_DEBUGGABLE) > 0;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            this.canUseLogcat = true;
+        } else {
+            this.canUseLogcat = pm.checkPermission(Manifest.permission.READ_LOGS, packageName) == PackageManager.PERMISSION_GRANTED;
+        }
+
+        this.sdkVersion = info.metaData.getInt("com.deploygate.sdk.version", 0);
+    }
+}

--- a/sdk/src/main/java/com/deploygate/sdk/HostApp.java
+++ b/sdk/src/main/java/com/deploygate/sdk/HostApp.java
@@ -35,7 +35,7 @@ class HostApp {
             return;
         }
 
-        this.debuggable = (info.flags & ApplicationInfo.FLAG_DEBUGGABLE) > 0;
+        this.debuggable = (info.flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             this.canUseLogcat = true;

--- a/sdk/src/main/java/com/deploygate/sdk/LogcatInstructionSerializer.java
+++ b/sdk/src/main/java/com/deploygate/sdk/LogcatInstructionSerializer.java
@@ -193,7 +193,7 @@ class LogcatInstructionSerializer implements ILogcatInstructionSerializer {
             }
 
             if (Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1 <= Build.VERSION.SDK_INT) {
-                if (Compatibility.isLogcatBundleSupported() && (e instanceof TransactionTooLargeException)) {
+                if (DeployGate.isFeatureSupported(Compatibility.LOGCAT_BUNDLE) && (e instanceof TransactionTooLargeException)) {
                     return SEND_LOGCAT_RESULT_FAILURE_REQUEST_CHUNK_CHALLENGE;
                 }
             }

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -55,6 +55,10 @@ public interface DeployGateEvent {
     public static final String EXTRA_CURRENT_REVISION = "currentRevision";
     public static final String EXTRA_CURRENT_DISTRIBUTION_ID = "currentDistributionId";
     public static final String EXTRA_CURRENT_DISTRIBUTION_TITLE = "currentDistributionTitle";
+    /**
+     * this key shouldn't be used
+     */
+    @Deprecated
     public static final String EXTRA_DEPLOYGATE_VERSION_CODE = "deploygateVersionCode";
     public static final String EXTRA_COMMENT = "comment";
     public static final String EXTRA_DISTRIBUTION_USER_NAME = "distributionUserName";

--- a/sdk/src/test/java/com/deploygate/sdk/CompatibilityTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CompatibilityTest.java
@@ -5,63 +5,29 @@ import com.google.common.truth.Truth;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 @RunWith(JUnit4.class)
 public class CompatibilityTest {
 
     @Test
-    public void check_isUpdateMessageOfBuildSupported() {
+    public void check_SUPPORT_UPDATE_MESSAGE_OF_BUILD() {
         Truth.assertThat(Compatibility.ClientVersion.SUPPORT_UPDATE_MESSAGE_OF_BUILD).isEqualTo(39);
-
-        try (MockedStatic<DeployGate> mocked = Mockito.mockStatic(DeployGate.class)) {
-            mocked.when(new MockedStatic.Verification() {
-                @Override
-                public void apply() throws Throwable {
-                    DeployGate.getDeployGateVersionCode();
-                }
-            }).thenReturn(38, 39, 40);
-
-            Truth.assertThat(Compatibility.isUpdateMessageOfBuildSupported()).isFalse();
-            Truth.assertThat(Compatibility.isUpdateMessageOfBuildSupported()).isTrue();
-            Truth.assertThat(Compatibility.isUpdateMessageOfBuildSupported()).isTrue();
-        }
     }
 
     @Test
-    public void check_isSerializedExceptionSupported() {
+    public void check_SUPPORT_SERIALIZED_EXCEPTION() {
         Truth.assertThat(Compatibility.ClientVersion.SUPPORT_SERIALIZED_EXCEPTION).isEqualTo(42);
-
-        try (MockedStatic<DeployGate> mocked = Mockito.mockStatic(DeployGate.class)) {
-            mocked.when(new MockedStatic.Verification() {
-                @Override
-                public void apply() throws Throwable {
-                    DeployGate.getDeployGateVersionCode();
-                }
-            }).thenReturn(41, 42, 43);
-
-            Truth.assertThat(Compatibility.isSerializedExceptionSupported()).isFalse();
-            Truth.assertThat(Compatibility.isSerializedExceptionSupported()).isTrue();
-            Truth.assertThat(Compatibility.isSerializedExceptionSupported()).isTrue();
-        }
     }
 
     @Test
-    public void check_isLogcatBundleSupported() {
-        Truth.assertThat(Compatibility.ClientVersion.SUPPORT_LOGCAT_BUNDLE).isEqualTo(Integer.MAX_VALUE);
+    public void check_bitMask_uniqueness() {
+        for (final Compatibility c : Compatibility.values()) {
+            int tmp = c.bitMask;
 
-        try (MockedStatic<DeployGate> mocked = Mockito.mockStatic(DeployGate.class)) {
-            mocked.when(new MockedStatic.Verification() {
-                @Override
-                public void apply() throws Throwable {
-                    DeployGate.getDeployGateVersionCode();
-                }
-            }).thenReturn(Integer.MAX_VALUE - 1, Integer.MAX_VALUE, Integer.MAX_VALUE);
-
-            Truth.assertThat(Compatibility.isLogcatBundleSupported()).isFalse();
-            Truth.assertThat(Compatibility.isLogcatBundleSupported()).isTrue();
-            Truth.assertThat(Compatibility.isLogcatBundleSupported()).isTrue();
+            while (tmp > 1) {
+                Truth.assertThat(tmp % 2).isEqualTo(0);
+                tmp /= 2;
+            }
         }
     }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/CompatibilityTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CompatibilityTest.java
@@ -24,10 +24,17 @@ public class CompatibilityTest {
         for (final Compatibility c : Compatibility.values()) {
             int tmp = c.bitMask;
 
-            while (tmp > 1) {
-                Truth.assertThat(tmp % 2).isEqualTo(0);
-                tmp /= 2;
+            while (tmp != 1) {
+                Truth.assertThat(tmp & 1).isEqualTo(0);
+                tmp >>>= 1;
             }
         }
+    }
+
+    @Test
+    public void check_bitMask_value() {
+        Truth.assertThat(Compatibility.UPDATE_MESSAGE_OF_BUILD.bitMask).isEqualTo(1);
+        Truth.assertThat(Compatibility.SERIALIZED_EXCEPTION.bitMask).isEqualTo(2);
+        Truth.assertThat(Compatibility.LOGCAT_BUNDLE.bitMask).isEqualTo(4);
     }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/DeployGateClientTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/DeployGateClientTest.java
@@ -1,0 +1,252 @@
+package com.deploygate.sdk;
+
+import android.app.Application;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.Signature;
+import android.content.pm.SigningInfo;
+import android.os.Build;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.google.common.truth.Truth;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.robolectric.Shadows;
+import org.robolectric.shadows.ShadowPackageManager;
+
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+
+@RunWith(AndroidJUnit4.class)
+public class DeployGateClientTest {
+    @NonNull
+    Application app;
+
+    @Before
+    public void setUp() {
+        app = getApplicationContext();
+    }
+
+    @Test
+    public void return_defaults_unless_installed() {
+        DeployGateClient client = new DeployGateClient(app, "com.deploygate");
+        Truth.assertThat(client.isInstalled).isFalse();
+        Truth.assertThat(client.versionCode).isEqualTo(0);
+
+        for (final Compatibility compatibility : Compatibility.values()) {
+            Truth.assertThat(client.isSupported(compatibility)).isFalse();
+        }
+    }
+
+    @Test
+    public void return_defaults_if_signature_is_not_matched() {
+        DeployGateClient client = installDeployGate(100, false, Compatibility.all());
+
+        Truth.assertThat(client.isInstalled).isFalse();
+        Truth.assertThat(client.versionCode).isEqualTo(0);
+
+        for (final Compatibility compatibility : Compatibility.values()) {
+            Truth.assertThat(client.isSupported(compatibility)).isFalse();
+        }
+    }
+
+    @Test
+    public void check_features_if_client_version_is_38() {
+        DeployGateClient client = installDeployGate(Compatibility.ClientVersion.SUPPORT_UPDATE_MESSAGE_OF_BUILD - 1, true, -1);
+
+        for (final Compatibility compatibility : Compatibility.values()) {
+            Truth.assertThat(client.isSupported(compatibility)).isFalse();
+        }
+    }
+
+    @Test
+    public void check_features_if_client_version_is_39() {
+        DeployGateClient client = installDeployGate(Compatibility.ClientVersion.SUPPORT_UPDATE_MESSAGE_OF_BUILD, true, -1);
+
+        for (final Compatibility compatibility : Compatibility.values()) {
+            switch (compatibility) {
+                case UPDATE_MESSAGE_OF_BUILD: {
+                    Truth.assertThat(client.isSupported(compatibility)).isTrue();
+                    break;
+                }
+                default: {
+                    Truth.assertThat(client.isSupported(compatibility)).isFalse();
+                    break;
+                }
+            }
+        }
+    }
+
+    @Test
+    public void check_features_if_client_version_is_41() {
+        DeployGateClient client = installDeployGate(Compatibility.ClientVersion.SUPPORT_SERIALIZED_EXCEPTION - 1, true, -1);
+
+        for (final Compatibility compatibility : Compatibility.values()) {
+            switch (compatibility) {
+                case UPDATE_MESSAGE_OF_BUILD: {
+                    Truth.assertThat(client.isSupported(compatibility)).isTrue();
+                    break;
+                }
+                default: {
+                    Truth.assertThat(client.isSupported(compatibility)).isFalse();
+                    break;
+                }
+            }
+        }
+    }
+
+    @Test
+    public void check_features_if_client_version_is_42() {
+        DeployGateClient client = installDeployGate(Compatibility.ClientVersion.SUPPORT_SERIALIZED_EXCEPTION, true, -1);
+
+        for (final Compatibility compatibility : Compatibility.values()) {
+            switch (compatibility) {
+                case UPDATE_MESSAGE_OF_BUILD:
+                case SERIALIZED_EXCEPTION: {
+                    Truth.assertThat(client.isSupported(compatibility)).isTrue();
+                    break;
+                }
+                default: {
+                    Truth.assertThat(client.isSupported(compatibility)).isFalse();
+                    break;
+                }
+            }
+        }
+    }
+
+    @Test
+    public void check_features_if_features_has_build_message() {
+        DeployGateClient client = installDeployGate(100, true, 0b1);
+
+        Truth.assertThat(client.isInstalled).isTrue();
+        Truth.assertThat(client.versionCode).isEqualTo(100);
+
+        for (final Compatibility compatibility : Compatibility.values()) {
+            switch (compatibility) {
+                case UPDATE_MESSAGE_OF_BUILD: {
+                    Truth.assertThat(client.isSupported(compatibility)).isTrue();
+                    break;
+                }
+                default: {
+                    Truth.assertThat(client.isSupported(compatibility)).isFalse();
+                    break;
+                }
+            }
+        }
+    }
+
+    @Test
+    public void check_features_if_features_has_serialized_exception() {
+        DeployGateClient client = installDeployGate(100, true, 0b10);
+
+        Truth.assertThat(client.isInstalled).isTrue();
+        Truth.assertThat(client.versionCode).isEqualTo(100);
+
+        for (final Compatibility compatibility : Compatibility.values()) {
+            switch (compatibility) {
+                case SERIALIZED_EXCEPTION: {
+                    Truth.assertThat(client.isSupported(compatibility)).isTrue();
+                    break;
+                }
+                default: {
+                    Truth.assertThat(client.isSupported(compatibility)).isFalse();
+                    break;
+                }
+            }
+        }
+    }
+
+    @Test
+    public void check_features_if_features_has_logcat_bundle() {
+        DeployGateClient client = installDeployGate(100, true, 0b100);
+
+        Truth.assertThat(client.isInstalled).isTrue();
+        Truth.assertThat(client.versionCode).isEqualTo(100);
+
+        for (final Compatibility compatibility : Compatibility.values()) {
+            switch (compatibility) {
+                case LOGCAT_BUNDLE: {
+                    Truth.assertThat(client.isSupported(compatibility)).isTrue();
+                    break;
+                }
+                default: {
+                    Truth.assertThat(client.isSupported(compatibility)).isFalse();
+                    break;
+                }
+            }
+        }
+    }
+
+    @Test
+    public void check_features_if_features_has_serialized_exception_and_logcat_bundle() {
+        DeployGateClient client = installDeployGate(100, true, 0b110);
+
+        Truth.assertThat(client.isInstalled).isTrue();
+        Truth.assertThat(client.versionCode).isEqualTo(100);
+
+        for (final Compatibility compatibility : Compatibility.values()) {
+            switch (compatibility) {
+                case SERIALIZED_EXCEPTION:
+                case LOGCAT_BUNDLE: {
+                    Truth.assertThat(client.isSupported(compatibility)).isTrue();
+                    break;
+                }
+                default: {
+                    Truth.assertThat(client.isSupported(compatibility)).isFalse();
+                    break;
+                }
+            }
+        }
+    }
+
+    private DeployGateClient installDeployGate(
+            long versionCode,
+            boolean matchSignature,
+            int features
+    ) {
+        ShadowPackageManager packageManager = Shadows.shadowOf(app.getPackageManager());
+
+        PackageInfo packageInfo = new PackageInfo();
+
+        packageInfo.setLongVersionCode(versionCode);
+        packageInfo.versionName = "1.0.0";
+        packageInfo.packageName = "com.deploygate";
+
+        if (Build.VERSION_CODES.P > Build.VERSION.SDK_INT) {
+            packageInfo.signatures = new Signature[0];
+        } else {
+            packageInfo.signingInfo = new SigningInfo();
+        }
+
+        Bundle metaData = new Bundle();
+
+        if (features > 0) {
+            metaData.putInt("com.deploygate.features", features);
+        }
+
+        ApplicationInfo applicationInfo = new ApplicationInfo();
+        applicationInfo.packageName = "com.deploygate";
+        applicationInfo.metaData = metaData;
+
+        packageInfo.applicationInfo = applicationInfo;
+
+        packageManager.installPackage(packageInfo);
+
+        try (MockedStatic<DeployGateClient> mocked = Mockito.mockStatic(DeployGateClient.class)) {
+            mocked.when(new MockedStatic.Verification() {
+                @Override
+                public void apply() throws Throwable {
+                    DeployGateClient.checkSignature(Mockito.<Signature[]>any());
+                }
+            }).thenReturn(matchSignature);
+
+            return new DeployGateClient(app, "com.deploygate");
+        }
+    }
+}

--- a/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
@@ -275,6 +275,11 @@ public class DeployGateInterfaceTest {
     }
 
     @Test
+    public void getDeployGateLongVersionCode() {
+        Truth.assertThat(DeployGate.getDeployGateLongVersionCode()).isEqualTo(0);
+    }
+
+    @Test
     public void hasUpdate() {
         Truth.assertThat(DeployGate.hasUpdate()).isFalse();
     }

--- a/sdk/src/test/java/com/deploygate/sdk/HostAppTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/HostAppTest.java
@@ -1,0 +1,46 @@
+package com.deploygate.sdk;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.google.common.truth.Truth;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+
+@RunWith(AndroidJUnit4.class)
+public class HostAppTest {
+    @NonNull
+    private Context context;
+
+    @Before
+    public void setUp() {
+        context = getApplicationContext();
+    }
+
+    @Test
+    public void default_properties() {
+        HostApp app = new HostApp(context);
+
+        Truth.assertThat(app.debuggable).isTrue();
+        Truth.assertThat(app.canUseLogcat).isTrue();
+        Truth.assertThat(app.packageName).isEqualTo("com.deploygate.sdk.test");
+        Truth.assertThat(app.sdkVersion).isEqualTo(4);
+    }
+
+    @Test
+    @Config(sdk = 16)
+    public void canUseLogcat_is_true_if_sdk_is_equal_to_jb() {
+        HostApp app = new HostApp(context);
+
+        Truth.assertThat(app.canUseLogcat).isTrue();
+    }
+
+    // sdk 15 or lower is not available for robolectric...
+}

--- a/sdk/src/test/java/com/deploygate/sdk/LogcatInstructionSerializerTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/LogcatInstructionSerializerTest.java
@@ -140,11 +140,11 @@ public class LogcatInstructionSerializerTest {
         Truth.assertThat(instructionSerializer.sendSingleChunk(retryExceeded)).isEqualTo(LogcatInstructionSerializer.SEND_LOGCAT_RESULT_FAILURE_RETRIABLE);
         Truth.assertThat(instructionSerializer.sendSingleChunk(retryExceeded)).isEqualTo(LogcatInstructionSerializer.SEND_LOGCAT_RESULT_FAILURE_RETRY_EXCEEDED);
 
-        try (MockedStatic<Compatibility> mocked = Mockito.mockStatic(Compatibility.class)) {
+        try (MockedStatic<DeployGate> mocked = Mockito.mockStatic(DeployGate.class)) {
             mocked.when(new MockedStatic.Verification() {
                 @Override
                 public void apply() throws Throwable {
-                    Compatibility.isLogcatBundleSupported();
+                    DeployGate.isFeatureSupported(Compatibility.LOGCAT_BUNDLE);
                 }
             }).thenReturn(false, true);
 

--- a/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -133,6 +133,10 @@ public class DeployGate {
         return 0;
     }
 
+    public static long getDeployGateLongVersionCode() {
+        return 0;
+    }
+
     public static boolean hasUpdate() {
         return false;
     }


### PR DESCRIPTION
As for several values, we don't need to wait for the callback response from the client app.

- Embed the sdk version in the manifest file.
  - This means the client app can know the version before getting a reply from SDK. No problem even if it's faked. (It's possible to fake the value on the current implementation in the first place.)
- The client app will tell SDK about supported features through metadata.
  - Use bit operators to reduce the metadata size
  - Now SDK don't need to know which version has the feature compatibility.