### PR TITLE
Use publishReleasePublicationToMavenRepository to publish release artifacts

### DIFF
--- a/publishing.build.gradle
+++ b/publishing.build.gradle
@@ -90,7 +90,7 @@ afterEvaluate {
     }
 
     signing {
-        required { isRelease() && gradle.taskGraph.hasTask("publishToMavenRepository") }
+        required { isRelease() && gradle.taskGraph.hasTask("publishReleasePublicationToMavenRepository") }
 
         def signingKey = findProperty("signingKey")
         def signingPassword = findProperty("signingPassword")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 
 ./gradlew clean \
     sdk:verifyBytecodeVersionRelease sdkMock:verifyBytecodeVersionRelease \
-    sdk:publishToMavenRepository sdkMock:publishToMavenRepository \
+    sdk:publishReleasePublicationToMavenRepository sdkMock:publishReleasePublicationToMavenRepository \
     --stacktrace


### PR DESCRIPTION
Aggregation tasks had disappeared? We should use publishReleasePublicationToMavenRepository anyway.

![ss 2022-05-10 at 17 43 09](https://user-images.githubusercontent.com/4340693/167587659-83456d90-05f7-437f-989d-e3a335ebbde8.png)
