### PR TITLE
Use GITHUB_OUTPUT instead of set-output command

### DIFF
--- a/.github/workflows/deploy-javadoc.yml
+++ b/.github/workflows/deploy-javadoc.yml
@@ -30,9 +30,9 @@ jobs:
       - id: has-new-release
         run: |
           if [[ -d "${{ steps.latest-version.outputs.result }}" ]]; then
-            echo '::set-output name=result::false'
+            echo 'result=false' >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=result::true'
+            echo 'result=true' >> $GITHUB_OUTPUT
           fi
     outputs:
       has-new-release: ${{ steps.has-new-release.outputs.result }}


### PR DESCRIPTION
It will fail since June 1st as https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ announced.