### PR TITLE
Specify export flag for Context-based receiver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: cimg/android:2023.07
     working_directory: ~/deploygate-android-sdk
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false'
 
 commands:
   restore_gradle_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   android:
     docker:
-      - image: cimg/android:2022.03
+      - image: cimg/android:2023.07
     working_directory: ~/deploygate-android-sdk
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: '8.x'
+          java-version: '17.x'
           java-package: jdk
           distribution: 'temurin'
           cache: 'gradle'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: '8.x'
+          java-version: '17.x'
           java-package: jdk
           distribution: 'temurin'
           cache: 'gradle'
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: '8.x'
+          java-version: '17.x'
           java-package: jdk
           distribution: 'temurin'
           cache: 'gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,11 @@ buildscript {
     repositories {
         mavenCentral()
         google()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
-        classpath 'com.akaita.android:easylauncher:1.3.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.project.starter:easylauncher:5.0.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.akaita.android.easylauncher'
+apply plugin: 'com.starter.easylauncher'
 
 android {
-    compileSdkVersion = 32
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.deploygate.sample"
         minSdkVersion 14
-        targetSdkVersion 32
+        targetSdkVersion 33
     }
 
     buildTypes {
@@ -56,7 +56,7 @@ android {
 }
 
 easylauncher {
-    defaultFlavorNaming = true
+    defaultFlavorNaming true
 
     productFlavors {
         devreal {

--- a/sdk.build.gradle
+++ b/sdk.build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'maven-publish'
 version = rootProject.ext.releaseVersion
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 29
+        targetSdkVersion 33
         versionCode 1
         versionName project.version
         manifestPlaceholders = [sdkVersion:"4"]

--- a/sdk.build.gradle
+++ b/sdk.build.gradle
@@ -40,11 +40,11 @@ android {
 }
 
 dependencies {
-    testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation 'androidx.test.ext:junit:1.1.1'
-    testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation 'androidx.test:runner:1.5.2'
+    testImplementation 'androidx.test.ext:junit:1.1.5'
+    testImplementation 'org.robolectric:robolectric:4.10.3'
 
-    testImplementation 'androidx.test:rules:1.2.0'
+    testImplementation 'androidx.test:rules:1.5.0'
     testImplementation 'com.google.truth:truth:1.0'
 }
 

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
@@ -259,7 +260,7 @@ public class DeployGate {
 
     private void prepareBroadcastReceiver() {
         IntentFilter filter = new IntentFilter(ACTION_DEPLOYGATE_STARTED);
-        mApplicationContext.registerReceiver(new BroadcastReceiver() {
+        BroadcastReceiver receiver = new BroadcastReceiver() {
             @Override
             public void onReceive(
                     Context context,
@@ -272,7 +273,13 @@ public class DeployGate {
                     bindToService(false);
                 }
             }
-        }, filter);
+        };
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            mApplicationContext.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED);
+        } else {
+            mApplicationContext.registerReceiver(receiver, filter);
+        }
     }
 
     private void bindToService(final boolean isBoot) {


### PR DESCRIPTION
This feature has been introduced since Android 13 SDK (https://developer.android.com/about/versions/13/features#runtime-receivers) and it's now required for apps that target Android 14 or later (https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported).

See the implementation of ContextCompat for the verification. https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:core/core/src/main/java/androidx/core/content/ContextCompat.java;drc=b63ff8c4299a6486bf34ec2ac746517e2d378d43