### PR TITLE
Embed SDK's artifact version in meta-data tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 ext {
+    // sdk/java/com/deploygate/sdk/HostAppTest.java needs to be changed for a new release
     releaseVersion = '4.6.1'
 }
 

--- a/sdk.build.gradle
+++ b/sdk.build.gradle
@@ -37,7 +37,8 @@ android {
 
         manifestPlaceholders += [
                 featureFlags: flags,
-                sdkVersion: "4"
+                sdkVersion: "4",
+                sdkArtifactVersion: project.version,
         ]
     }
 

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -15,6 +15,11 @@
             />
 
         <meta-data
+            android:name="com.deploygate.sdk.artifact_version"
+            android:value="${sdkArtifactVersion}"
+            />
+
+        <meta-data
             android:name="com.deploygate.sdk.feature_flags"
             android:value="${featureFlags}"
             />

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -361,6 +361,7 @@ public class DeployGate {
         args.putBoolean(DeployGateEvent.EXTRA_CAN_LOGCAT, mHostApp.canUseLogcat);
         args.putString(DeployGateEvent.EXTRA_EXPECTED_AUTHOR, mExpectedAuthor);
         args.putInt(DeployGateEvent.EXTRA_SDK_VERSION, mHostApp.sdkVersion);
+        args.putString(DeployGateEvent.EXTRA_SDK_ARTIFACT_VERSION, mHostApp.sdkArtifactVersion);
         try {
             mRemoteService.init(mRemoteCallback, mHostApp.packageName, args);
         } catch (RemoteException e) {

--- a/sdk/src/main/java/com/deploygate/sdk/HostApp.java
+++ b/sdk/src/main/java/com/deploygate/sdk/HostApp.java
@@ -13,6 +13,7 @@ class HostApp {
     public final boolean canUseLogcat;
     public final boolean debuggable;
     public final int sdkVersion;
+    public final String sdkArtifactVersion;
 
     HostApp(
             Context context
@@ -32,6 +33,7 @@ class HostApp {
             this.debuggable = false;
             this.canUseLogcat = false;
             this.sdkVersion = 0;
+            this.sdkArtifactVersion = null;
             return;
         }
 
@@ -44,5 +46,6 @@ class HostApp {
         }
 
         this.sdkVersion = info.metaData.getInt("com.deploygate.sdk.version", 0);
+        this.sdkArtifactVersion = info.metaData.getString("com.deploygate.sdk.artifact_version");
     }
 }

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -29,7 +29,18 @@ public interface DeployGateEvent {
 
     public static final String EXTRA_AUTHOR = "author";
     public static final String EXTRA_EXPECTED_AUTHOR = "expectedAuthor";
+
+    /**
+     * A SDK's model version queried by this key from INIT event.
+     */
     public static final String EXTRA_SDK_VERSION = "sdkVersion";
+
+    /**
+     * A SDK's artifact version queried by this key from INIT event.
+     *
+     * @since 4.7.0
+     */
+    public static final String EXTRA_SDK_ARTIFACT_VERSION = "e.sdk-artifact-version";
     public static final String EXTRA_IS_MANAGED = "isManaged";
     public static final String EXTRA_IS_AUTHORIZED = "isAuthorized";
     public static final String EXTRA_LOGIN_USERNAME = "loginUsername";

--- a/sdk/src/test/java/com/deploygate/sdk/HostAppTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/HostAppTest.java
@@ -32,6 +32,7 @@ public class HostAppTest {
         Truth.assertThat(app.canUseLogcat).isTrue();
         Truth.assertThat(app.packageName).isEqualTo("com.deploygate.sdk.test");
         Truth.assertThat(app.sdkVersion).isEqualTo(4);
+        Truth.assertThat(app.sdkArtifactVersion).isEqualTo("4.6.1");
     }
 
     @Test


### PR DESCRIPTION
This is useful for host apps to control SDK functionalities more flexible.

NOTE: This can be overridden by developers, however, there is no problem cuz this is not an authentication/authorization stuff. Such cheat wouldn't bring any benefit to developers but may cause app crashes or unexpected behaviours.