### PR TITLE
Provide opt-out for crash reporting and device capture features

### DIFF
--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -707,18 +707,14 @@ public class DeployGate {
             boolean forceApplyOnReleaseBuild,
             CustomLogConfiguration customLogConfiguration
     ) {
-        DeployGateSdkConfiguration.Builder builder = new DeployGateSdkConfiguration.Builder()
-                .setAppOwnerName(author)
-                .setCustomLogConfiguration(customLogConfiguration)
-                .setCallback(callback);
-
-        if (forceApplyOnReleaseBuild) {
-            builder.setEnabledOnNonDebuggableBuild(false);
-        }
-
         install(
                 app,
-                builder.build()
+                new DeployGateSdkConfiguration.Builder()
+                        .setAppOwnerName(author)
+                        .setCustomLogConfiguration(customLogConfiguration)
+                        .setEnabledOnNonDebuggableBuild(forceApplyOnReleaseBuild)
+                        .setCallback(callback)
+                        .build()
         );
     }
 

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGateSdkConfiguration.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGateSdkConfiguration.java
@@ -1,0 +1,180 @@
+package com.deploygate.sdk;
+
+import com.deploygate.sdk.internal.annotations.Experimental;
+
+public final class DeployGateSdkConfiguration {
+    final CustomLogConfiguration customLogConfiguration;
+
+    final boolean isDisabled;
+    final boolean isEnabledOnNonDebuggableBuild;
+
+    final String appOwnerName;
+
+    final boolean isCrashReportingEnabled;
+
+
+    final DeployGateCallback callback;
+
+    final boolean isCaptureEnabled;
+
+    private DeployGateSdkConfiguration(
+    ) {
+        this(
+                true,
+                new CustomLogConfiguration.Builder().build(),
+                false,
+                null,
+                false,
+                false,
+                null
+        );
+    }
+
+    private DeployGateSdkConfiguration(
+            Builder builder
+    ) {
+        this(
+                builder.isDisabled,
+                builder.customLogConfiguration,
+                builder.isEnabledOnNonDebuggableBuild,
+                builder.appOwnerName,
+                builder.isCrashReportingEnabled,
+                builder.isCaptureEnabled,
+                builder.callback
+        );
+    }
+
+    private DeployGateSdkConfiguration(
+            boolean isDisabled,
+            CustomLogConfiguration customLogConfiguration,
+            boolean isEnabledOnNonDebuggableBuild,
+            String appOwnerName,
+            boolean isCrashReportingEnabled,
+            boolean isCaptureEnabled,
+            DeployGateCallback callback
+    ) {
+        this.customLogConfiguration = customLogConfiguration;
+        this.isDisabled = isDisabled;
+        this.isEnabledOnNonDebuggableBuild = isEnabledOnNonDebuggableBuild;
+        this.appOwnerName = appOwnerName;
+        this.isCrashReportingEnabled = isCrashReportingEnabled;
+        this.isCaptureEnabled = isCaptureEnabled;
+        this.callback = callback;
+    }
+
+    public static final class Builder {
+        private CustomLogConfiguration customLogConfiguration = new CustomLogConfiguration.Builder().build();
+
+        private boolean isDisabled = false;
+        private boolean isEnabledOnNonDebuggableBuild = false;
+
+        private String appOwnerName = null;
+
+        private boolean isCrashReportingEnabled = true;
+
+        private boolean isCaptureEnabled = true;
+
+        private DeployGateCallback callback = null;
+
+        public Builder() {
+        }
+
+        /**
+         * Set a custom log configuration
+         *
+         * @param customLogConfiguration
+         *   a configuration object for custom logs like {@link DeployGate#logDebug(String)}
+         * @see CustomLogConfiguration
+         * @return self
+         */
+        @Experimental
+        public Builder setCustomLogConfiguration(CustomLogConfiguration customLogConfiguration) {
+            this.customLogConfiguration = customLogConfiguration;
+            return this;
+        }
+
+        /**
+         * Ensure the authority of this app to prevent casual redistribution via DeployGate.
+         *
+         * @param appOwnerName
+         *    A name of this app's owner on DeployGate.
+         * @return self
+         */
+        public Builder setAppOwnerName(String appOwnerName) {
+            this.appOwnerName = appOwnerName;
+            return this;
+        }
+
+        /**
+         * Disable all SDK features.
+         *
+         * @param disabled
+         *   Specify true if you would like to disable SDK completely. Defaults to false.
+         * @return self
+         */
+        public Builder setDisabled(boolean disabled) {
+            isDisabled = disabled;
+            return this;
+        }
+
+        /**
+         * Enable SDK even on non-debuggable builds.
+         *
+         * @param enabledOnNonDebuggableBuild
+         *   Specify true if you would like to enable SDK on non-debuggable builds. Defaults to false.
+         * @return self
+         */
+        public Builder setEnabledOnNonDebuggableBuild(boolean enabledOnNonDebuggableBuild) {
+            isEnabledOnNonDebuggableBuild = enabledOnNonDebuggableBuild;
+            return this;
+        }
+
+        /**
+         * Enable DeployGate Capture feature.
+         *
+         * @param captureEnabled
+         *   Specify true if you would like to use DeployGate Capture feature if available. Otherwise, false. Defaults to true.
+         * @return self
+         */
+        @Experimental
+        public Builder setCaptureEnabled(boolean captureEnabled) {
+            isCaptureEnabled = captureEnabled;
+            return this;
+        }
+
+        /**
+         * Enable DeployGate Crash reporting feature.
+         *
+         * @param crashReportingEnabled
+         *   Specify true if you would like to use DeployGate Crash reporting feature. Otherwise, false. Defaults to true.
+         * @return self
+         */
+        public Builder setCrashReportingEnabled(boolean crashReportingEnabled) {
+            isCrashReportingEnabled = crashReportingEnabled;
+            return this;
+        }
+
+        /**
+         * Set a callback of the communication events between DeployGate client app and this app.
+         *
+         * @param callback
+         *   Set an instance of callback. The reference won't be released. Please use {@link DeployGate#registerCallback(DeployGateCallback, boolean)} for memory sensitive works.
+         * @return self
+         */
+        public Builder setCallback(DeployGateCallback callback) {
+            this.callback = callback;
+            return this;
+        }
+
+        /**
+         * @return a new sdk configuration.
+         */
+        public DeployGateSdkConfiguration build() {
+            if (isDisabled) {
+                return new DeployGateSdkConfiguration();
+            } else {
+                return new DeployGateSdkConfiguration(this);
+            }
+        }
+    }
+}

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGateSdkConfiguration.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGateSdkConfiguration.java
@@ -18,19 +18,6 @@ public final class DeployGateSdkConfiguration {
     final boolean isCaptureEnabled;
 
     private DeployGateSdkConfiguration(
-    ) {
-        this(
-                true,
-                new CustomLogConfiguration.Builder().build(),
-                false,
-                null,
-                false,
-                false,
-                null
-        );
-    }
-
-    private DeployGateSdkConfiguration(
             Builder builder
     ) {
         this(
@@ -171,7 +158,8 @@ public final class DeployGateSdkConfiguration {
          */
         public DeployGateSdkConfiguration build() {
             if (isDisabled) {
-                return new DeployGateSdkConfiguration();
+                // Create a new builder instance to release all references just in case.
+                return new DeployGateSdkConfiguration(new Builder().setDisabled(true));
             } else {
                 return new DeployGateSdkConfiguration(this);
             }

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -41,6 +41,13 @@ public interface DeployGateEvent {
      * @since 4.7.0
      */
     public static final String EXTRA_SDK_ARTIFACT_VERSION = "e.sdk-artifact-version";
+
+    /**
+     * Only active feature flags on this host app.
+     *
+     * @since 4.7.0
+     */
+    public static final String EXTRA_ACTIVE_FEATURE_FLAGS = "e.active-feature-flags";
     public static final String EXTRA_IS_MANAGED = "isManaged";
     public static final String EXTRA_IS_AUTHORIZED = "isAuthorized";
     public static final String EXTRA_LOGIN_USERNAME = "loginUsername";

--- a/sdk/src/test/java/com/deploygate/sdk/HostAppTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/HostAppTest.java
@@ -26,22 +26,65 @@ public class HostAppTest {
 
     @Test
     public void default_properties() {
-        HostApp app = new HostApp(context);
+        HostApp app = new HostApp(
+                context,
+                new DeployGateSdkConfiguration.Builder().build()
+        );
 
         Truth.assertThat(app.debuggable).isTrue();
         Truth.assertThat(app.canUseLogcat).isTrue();
         Truth.assertThat(app.packageName).isEqualTo("com.deploygate.sdk.test");
         Truth.assertThat(app.sdkVersion).isEqualTo(4);
         Truth.assertThat(app.sdkArtifactVersion).isEqualTo("4.6.1");
+        Truth.assertThat(app.activeFeatureFlags).isEqualTo(31);
+        Truth.assertThat(app.canUseDeviceCapture()).isTrue();
     }
 
     @Test
     @Config(sdk = 16)
     public void canUseLogcat_is_true_if_sdk_is_equal_to_jb() {
-        HostApp app = new HostApp(context);
+        HostApp app = new HostApp(
+                context,
+                new DeployGateSdkConfiguration.Builder().build()
+        );
 
         Truth.assertThat(app.canUseLogcat).isTrue();
     }
 
     // sdk 15 or lower is not available for robolectric...
+
+    @Test
+    public void disabled_DeployGateSdkConfiguration_initialize_host_app_as_disabled() {
+        HostApp app = new HostApp(
+                context,
+                new DeployGateSdkConfiguration.Builder().setDisabled(true).build()
+        );
+
+        Truth.assertThat(app.debuggable).isFalse();
+        Truth.assertThat(app.canUseLogcat).isFalse();
+        Truth.assertThat(app.packageName).isEqualTo("com.deploygate.sdk.test");
+        Truth.assertThat(app.sdkVersion).isEqualTo(0);
+        Truth.assertThat(app.sdkArtifactVersion).isNull();
+        Truth.assertThat(app.activeFeatureFlags).isEqualTo(0);
+        Truth.assertThat(app.canUseDeviceCapture()).isFalse();
+    }
+
+    @Test
+    public void can_read_DeployGateSdkConfiguration_setCaptureEnabled() {
+        HostApp app1 = new HostApp(
+                context,
+                new DeployGateSdkConfiguration.Builder().setCaptureEnabled(true).build()
+        );
+
+        Truth.assertThat(app1.canUseDeviceCapture()).isTrue();
+        Truth.assertThat(app1.activeFeatureFlags).isEqualTo(31);
+
+        HostApp app2 = new HostApp(
+                context,
+                new DeployGateSdkConfiguration.Builder().setCaptureEnabled(false).build()
+        );
+
+        Truth.assertThat(app2.canUseDeviceCapture()).isFalse();
+        Truth.assertThat(app2.activeFeatureFlags).isEqualTo(15);
+    }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/HostAppTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/HostAppTest.java
@@ -31,7 +31,6 @@ public class HostAppTest {
                 new DeployGateSdkConfiguration.Builder().build()
         );
 
-        Truth.assertThat(app.debuggable).isTrue();
         Truth.assertThat(app.canUseLogcat).isTrue();
         Truth.assertThat(app.packageName).isEqualTo("com.deploygate.sdk.test");
         Truth.assertThat(app.sdkVersion).isEqualTo(4);
@@ -60,7 +59,6 @@ public class HostAppTest {
                 new DeployGateSdkConfiguration.Builder().setDisabled(true).build()
         );
 
-        Truth.assertThat(app.debuggable).isFalse();
         Truth.assertThat(app.canUseLogcat).isFalse();
         Truth.assertThat(app.packageName).isEqualTo("com.deploygate.sdk.test");
         Truth.assertThat(app.sdkVersion).isEqualTo(0);


### PR DESCRIPTION
Close #68

We should provide flexible configuration for users. Especially, opting-out data collection is getting important. Some of features are triggered by our client app, so SDK state must be delivered to our app through AIDL; We can know the active features from *init* event.