### PR TITLE
Add DeployGateSdkConfiguration class and DeployGate#install to sdkMock

### DIFF
--- a/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
@@ -61,6 +61,42 @@ public class DeployGateInterfaceTest {
     }
 
     @Test
+    public void install__Context_SdkConfiguration() {
+        DeployGate.install(
+                app,
+                new DeployGateSdkConfiguration.Builder()
+                        .setCaptureEnabled(false)
+                        .setDisabled(false)
+                        .setEnabledOnNonDebuggableBuild(false)
+                        .setAppOwnerName("sample")
+                        .setCrashReportingEnabled(false)
+                        .setCustomLogConfiguration(
+                                new CustomLogConfiguration.Builder()
+                                        .setBackpressure(CustomLogConfiguration.Backpressure.DROP_BUFFER_BY_OLDEST)
+                                        .setBufferSize(5)
+                                        .build()
+                        )
+                        .setCallback(new DeployGateCallback() {
+                            @Override
+                            public void onInitialized(boolean isServiceAvailable) {
+
+                            }
+
+                            @Override
+                            public void onStatusChanged(boolean isManaged, boolean isAuthorized, String loginUsername, boolean isStopped) {
+
+                            }
+
+                            @Override
+                            public void onUpdateAvailable(int revision, String versionName, int versionCode) {
+
+                            }
+                        })
+                        .build()
+        );
+    }
+
+    @Test
     public void install__Application() {
         DeployGate.install(app);
     }

--- a/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -3,9 +3,6 @@ package com.deploygate.sdk;
 import android.app.Application;
 import android.content.Context;
 
-/**
- * @noinspection ALL
- */
 public class DeployGate {
 
     static void clear() {

--- a/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -1,10 +1,20 @@
 package com.deploygate.sdk;
 
 import android.app.Application;
+import android.content.Context;
 
+/**
+ * @noinspection ALL
+ */
 public class DeployGate {
 
     static void clear() {
+    }
+
+    public static void install(
+            Context context,
+            DeployGateSdkConfiguration sdkConfiguration
+    ) {
     }
 
     public static void install(Application app) {

--- a/sdkMock/src/main/java/com/deploygate/sdk/DeployGateSdkConfiguration.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/DeployGateSdkConfiguration.java
@@ -1,0 +1,44 @@
+package com.deploygate.sdk;
+
+/** @noinspection ALL*/
+public final class DeployGateSdkConfiguration {
+    private DeployGateSdkConfiguration() {
+    }
+
+    public static final class Builder {
+        public Builder() {
+        }
+
+        public Builder setCustomLogConfiguration(CustomLogConfiguration customLogConfiguration) {
+            return this;
+        }
+
+        public Builder setAppOwnerName(String appOwnerName) {
+            return this;
+        }
+
+        public Builder setDisabled(boolean disabled) {
+            return this;
+        }
+
+        public Builder setEnabledOnNonDebuggableBuild(boolean enabledOnNonDebuggableBuild) {
+            return this;
+        }
+
+        public Builder setCaptureEnabled(boolean captureEnabled) {
+            return this;
+        }
+
+        public Builder setCrashReportingEnabled(boolean crashReportingEnabled) {
+            return this;
+        }
+
+        public Builder setCallback(DeployGateCallback callback) {
+            return this;
+        }
+
+        public DeployGateSdkConfiguration build() {
+            return new DeployGateSdkConfiguration();
+        }
+    }
+}

--- a/sdkMock/src/main/java/com/deploygate/sdk/DeployGateSdkConfiguration.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/DeployGateSdkConfiguration.java
@@ -1,6 +1,5 @@
 package com.deploygate.sdk;
 
-/** @noinspection ALL*/
 public final class DeployGateSdkConfiguration {
     private DeployGateSdkConfiguration() {
     }


### PR DESCRIPTION
Close #83 

DeployGateSdkConfiguration class and DeployGate#install method appears only in com.deploygate.sdk artifact so those who use the entities would be faced with compilation errors on variants that use sdk-mock dependency.

This PR adds the classes above to sdkMock module as well.

BTW, to solve this issue completely, we must introduce automated code-generation tool to produce sdkMock classes instead of maintaining independently.