### PR TITLE
Collect and send custom attributes for capture feature

### DIFF
--- a/plugins/library/src/main/java/com/deploygate/plugins/BaseSdkPlugin.kt
+++ b/plugins/library/src/main/java/com/deploygate/plugins/BaseSdkPlugin.kt
@@ -16,7 +16,7 @@ abstract class BaseSdkPlugin : Plugin<Project> {
         /**
          * sdk/java/com/deploygate/sdk/HostAppTest.java needs to be changed for a new release
          */
-        const val ARTIFACT_VERSION = "4.7.1"
+        const val ARTIFACT_VERSION = "4.8.0"
 
         val JAVA_VERSION = JavaVersion.VERSION_1_7
     }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -15,6 +15,9 @@
     <!-- only for sample app -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <!-- collecting stats data from app&device -->
+    <uses-permission android:name="com.deploygate.permission.ACCESS_SDK" />
+
     <!--
       If you have multiple processes in your application, or you want to customize SDK initializer,
       you need to add your own Application class here. In this example, the class is
@@ -67,4 +70,8 @@
         <!-- SDK will be initialized through ContentProvider by default -->
         <!-- Please refer to stablereal/AndroidManifest.xml -->
     </application>
+
+    <queries>
+        <provider android:authorities="com.deploygate.external.sdk" />
+    </queries>
 </manifest>

--- a/sample/src/main/java/com/deploygate/sample/App.java
+++ b/sample/src/main/java/com/deploygate/sample/App.java
@@ -1,9 +1,11 @@
 package com.deploygate.sample;
 
 import android.app.Application;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.util.Log;
 
+import com.deploygate.sdk.CustomAttributes;
 import com.deploygate.sdk.DeployGate;
 import com.deploygate.sdk.DeployGateCallback;
 
@@ -34,6 +36,14 @@ public class App extends Application {
                 if (isServiceAvailable) {
                     Log.i(TAG, "SDK is available");
                     DeployGate.logInfo("SDK is available");
+
+                    CustomAttributes attrs = new CustomAttributes();
+                    attrs.putString("build_type", BuildConfig.BUILD_TYPE);
+                    attrs.putString("flavor", BuildConfig.FLAVOR);
+                    attrs.putString("version_name", BuildConfig.VERSION_NAME);
+                    attrs.putInt("version_code", BuildConfig.VERSION_CODE);
+                    attrs.putString("application_id", BuildConfig.APPLICATION_ID);
+                    DeployGate.setRuntimeExtra(attrs);
                 } else {
                     Log.i(TAG, "SDK is unavailable");
                     DeployGate.logInfo("SDK is unavailable"); // this fails silently
@@ -83,5 +93,19 @@ public class App extends Application {
         // DeployGate.install(this, "YOURUSERNAME");
         //
         // You can use DeployGate.isAuthorized() later to check the installation is valid or not.
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        CustomAttributes attrs = DeployGate.getRuntimeExtra();
+        if (attrs == null) {
+            attrs = new CustomAttributes();
+        }
+        attrs.putString("locale", newConfig.locale.toString());
+        attrs.putInt("orientation", newConfig.orientation);
+        attrs.putFloat("font_scale", newConfig.fontScale);
+        DeployGate.setRuntimeExtra(attrs);
     }
 }

--- a/sample/src/main/java/com/deploygate/sample/App.java
+++ b/sample/src/main/java/com/deploygate/sample/App.java
@@ -37,13 +37,9 @@ public class App extends Application {
                     Log.i(TAG, "SDK is available");
                     DeployGate.logInfo("SDK is available");
 
-                    CustomAttributes attrs = new CustomAttributes();
+                    CustomAttributes attrs = DeployGate.getBuildEnvironment();
                     attrs.putString("build_type", BuildConfig.BUILD_TYPE);
                     attrs.putString("flavor", BuildConfig.FLAVOR);
-                    attrs.putString("version_name", BuildConfig.VERSION_NAME);
-                    attrs.putInt("version_code", BuildConfig.VERSION_CODE);
-                    attrs.putString("application_id", BuildConfig.APPLICATION_ID);
-                    DeployGate.setRuntimeExtra(attrs);
                 } else {
                     Log.i(TAG, "SDK is unavailable");
                     DeployGate.logInfo("SDK is unavailable"); // this fails silently
@@ -100,12 +96,8 @@ public class App extends Application {
         super.onConfigurationChanged(newConfig);
 
         CustomAttributes attrs = DeployGate.getRuntimeExtra();
-        if (attrs == null) {
-            attrs = new CustomAttributes();
-        }
         attrs.putString("locale", newConfig.locale.toString());
         attrs.putInt("orientation", newConfig.orientation);
         attrs.putFloat("font_scale", newConfig.fontScale);
-        DeployGate.setRuntimeExtra(attrs);
     }
 }

--- a/sample/src/main/java/com/deploygate/sample/SampleActivity.java
+++ b/sample/src/main/java/com/deploygate/sample/SampleActivity.java
@@ -57,16 +57,12 @@ public class SampleActivity extends Activity implements DeployGateCallback {
 
 
         CustomAttributes attrs = DeployGate.getRuntimeExtra();
-        if (attrs == null) {
-            attrs = new CustomAttributes();
-        }
         attrs.putString("string", "value");
         attrs.putInt("int", 123);
         attrs.putBoolean("boolean", true);
         attrs.putFloat("float", 1.23f);
         attrs.putDouble("double", 1.23);
         attrs.putLong("long", 123L);
-        DeployGate.setRuntimeExtra(attrs);
     }
 
     @Override

--- a/sample/src/main/java/com/deploygate/sample/SampleActivity.java
+++ b/sample/src/main/java/com/deploygate/sample/SampleActivity.java
@@ -14,6 +14,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.deploygate.sdk.CustomAttributes;
 import com.deploygate.sdk.DeployGate;
 import com.deploygate.sdk.DeployGateCallback;
 
@@ -53,6 +54,19 @@ public class SampleActivity extends Activity implements DeployGateCallback {
         mUpdateButton = (Button) findViewById(R.id.updateButton);
         mLogMessage = (EditText) findViewById(R.id.message);
         mDistributionComments = (LinearLayout) findViewById(R.id.distributionComments);
+
+
+        CustomAttributes attrs = DeployGate.getRuntimeExtra();
+        if (attrs == null) {
+            attrs = new CustomAttributes();
+        }
+        attrs.putString("string", "value");
+        attrs.putInt("int", 123);
+        attrs.putBoolean("boolean", true);
+        attrs.putFloat("float", 1.23f);
+        attrs.putDouble("double", 1.23);
+        attrs.putLong("long", 123L);
+        DeployGate.setRuntimeExtra(attrs);
     }
 
     @Override

--- a/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -7,6 +7,10 @@ import org.json.JSONObject;
 
 import java.util.regex.Pattern;
 
+/**
+ * This class provides store key-value pairs.
+ * These methods are thread-safe.
+ */
 public final class CustomAttributes {
 
   private static final String TAG = "CustomAttributes";
@@ -23,36 +27,91 @@ public final class CustomAttributes {
     attributes = new JSONObject();
   }
 
+  /**
+   * Put a string value with the key.
+   * If the key already exists, the value will be overwritten.
+   * @param key key must be non-null and match the valid pattern.
+   * @param value value must be non-null and its length must be less than 64.
+   * @return true if the value is put successfully, otherwise false.
+   * @see CustomAttributes#VALID_KEY_PATTERN
+   */
   public boolean putString(String key, String value) {
     return putInternal(key, value);
   }
 
+  /**
+   * Put an int value with the key.
+   * If the key already exists, the value will be overwritten.
+   * @param key key must be non-null and match the valid pattern.
+   * @param value int value
+   * @return true if the value is put successfully, otherwise false.
+   * @see CustomAttributes#VALID_KEY_PATTERN
+   */
   public boolean putInt(String key, int value) {
     return putInternal(key, value);
   }
 
+  /**
+   * Put a long value with the key.
+   * If the key already exists, the value will be overwritten.
+   * @param key key must be non-null and match the valid pattern.
+   * @param value long value
+   * @return true if the value is put successfully, otherwise false.
+   * @see CustomAttributes#VALID_KEY_PATTERN
+   */
   public boolean putLong(String key, long value) {
     return putInternal(key, value);
   }
 
+  /**
+   * Put a float value with the key.
+   * If the key already exists, the value will be overwritten.
+   * @param key key must be non-null and match the valid pattern.
+   * @param value float value
+   * @return true if the value is put successfully, otherwise false.
+   * @see CustomAttributes#VALID_KEY_PATTERN
+   */
   public boolean putFloat(String key, float value) {
     return putInternal(key, value);
   }
 
+  /**
+   * Put a double value with the key.
+   * If the key already exists, the value will be overwritten.
+   * @param key key must be non-null and match the valid pattern.
+   * @param value double value
+   * @return true if the value is put successfully, otherwise false.
+   * @see CustomAttributes#VALID_KEY_PATTERN
+   */
   public boolean putDouble(String key, double value) {
     return putInternal(key, value);
   }
 
+  /**
+   * Put a boolean value with the key.
+   * If the key already exists, the value will be overwritten.
+   * @param key key must be non-null and match the valid pattern.
+   * @param value boolean value
+   * @return true if the value is put successfully, otherwise false.
+   * @see CustomAttributes#VALID_KEY_PATTERN
+   */
   public boolean putBoolean(String key, boolean value) {
     return putInternal(key, value);
   }
 
+  /**
+   * Remove the value with the key.
+   * @param key name of the key to be removed.
+   */
   public void remove(String key) {
     synchronized (mLock) {
       attributes.remove(key);
     }
   }
 
+  /**
+   * Remove all key-value pairs.
+   */
   public void removeAll() {
     synchronized (mLock) {
       // recreate new object instead of removing all keys

--- a/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -13,8 +13,6 @@ public final class CustomAttributes {
 
   private static final int MAX_ATTRIBUTES_SIZE = 8;
   private static final Pattern VALID_KEY_PATTERN = Pattern.compile("^[a-z][_a-z0-9]{2,31}$");
-  private static final int MIN_KEY_LENGTH = 3;
-  private static final int MAX_KEY_LENGTH = 32;
   private static final int MAX_VALUE_LENGTH = 64;
 
   private final ConcurrentHashMap<String, Object> attributes;
@@ -91,7 +89,7 @@ public final class CustomAttributes {
       return false;
     }
 
-    if (key.length() < MIN_KEY_LENGTH || key.length() > MAX_KEY_LENGTH || !VALID_KEY_PATTERN.matcher(key).matches()) {
+    if (!VALID_KEY_PATTERN.matcher(key).matches()) {
       Log.w(TAG, "Invalid key: " + key);
       return false;
     }

--- a/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -7,7 +7,7 @@ import org.json.JSONObject;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
-public class CustomAttributes {
+public final class CustomAttributes {
 
   private static final String TAG = "CustomAttributes";
 
@@ -19,7 +19,7 @@ public class CustomAttributes {
 
   private final ConcurrentHashMap<String, Object> attributes;
 
-  public CustomAttributes() {
+  CustomAttributes() {
     attributes = new ConcurrentHashMap<>();
   }
 
@@ -63,7 +63,7 @@ public class CustomAttributes {
     return attributes.isEmpty();
   }
 
-  public String toJsonString() {
+  String toJsonString() {
     return new JSONObject(attributes).toString();
   }
 

--- a/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -17,7 +17,6 @@ public class CustomAttributes {
   private static final int MAX_KEY_LENGTH = 32;
   private static final int MAX_VALUE_LENGTH = 64;
 
-
   private final ConcurrentHashMap<String, Object> attributes;
 
   public CustomAttributes() {

--- a/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -59,6 +59,10 @@ public class CustomAttributes {
     return attributes.size();
   }
 
+  public boolean isEmpty() {
+    return attributes.isEmpty();
+  }
+
   public String toJsonString() {
     return new JSONObject(attributes).toString();
   }

--- a/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -1,0 +1,116 @@
+package com.deploygate.sdk;
+
+import android.util.Log;
+
+import org.json.JSONObject;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+public class CustomAttributes {
+
+  private static final String TAG = "CustomAttributes";
+
+  private static final int MAX_ATTRIBUTES_SIZE = 8;
+  private static final Pattern VALID_KEY_PATTERN = Pattern.compile("^[a-z][_a-z0-9]{2,31}$");
+  private static final int MIN_KEY_LENGTH = 3;
+  private static final int MAX_KEY_LENGTH = 32;
+  private static final int MAX_VALUE_LENGTH = 64;
+
+
+  private final ConcurrentHashMap<String, Object> attributes;
+
+  public CustomAttributes() {
+    attributes = new ConcurrentHashMap<>();
+  }
+
+  public boolean putString(String key, String value) {
+    return putInternal(key, value);
+  }
+
+  public boolean putInt(String key, int value) {
+    return putInternal(key, value);
+  }
+
+  public boolean putLong(String key, long value) {
+    return putInternal(key, value);
+  }
+
+  public boolean putFloat(String key, float value) {
+    return putInternal(key, value);
+  }
+
+  public boolean putDouble(String key, double value) {
+    return putInternal(key, value);
+  }
+
+  public boolean putBoolean(String key, boolean value) {
+    return putInternal(key, value);
+  }
+
+  public void remove(String key) {
+    attributes.remove(key);
+  }
+
+  public void removeAll() {
+    attributes.clear();
+  }
+
+  public int size() {
+    return attributes.size();
+  }
+
+  public String toJsonString() {
+    return new JSONObject(attributes).toString();
+  }
+
+  private boolean putInternal(String key, Object value) {
+    if (!isValidKey(key)) {
+      return false;
+    }
+
+    if (!isValidValue(value)) {
+      return false;
+    }
+
+    attributes.put(key, value);
+    return true;
+  }
+
+  private boolean isValidKey(String key) {
+    if (size() >= MAX_ATTRIBUTES_SIZE && !attributes.containsKey(key)) {
+      Log.w(TAG, "Attributes already reached max size. Ignored: " + key);
+      return false;
+    }
+
+    if (key == null || key.equals("true") || key.equals("false") || key.equals("null")) {
+      Log.w(TAG, "Not allowed key: " + key);
+      return false;
+    }
+
+    if (key.length() < MIN_KEY_LENGTH || key.length() > MAX_KEY_LENGTH || !VALID_KEY_PATTERN.matcher(key).matches()) {
+      Log.w(TAG, "Invalid key: " + key);
+      return false;
+    }
+
+    return true;
+  }
+
+  private boolean isValidValue(Object value) {
+    if (value == null) {
+      Log.w(TAG, "Value is null");
+      return false;
+    }
+
+    if (value instanceof String && ((String) value).length() > MAX_VALUE_LENGTH) {
+        Log.w(TAG, "Value too long: " + value);
+        return false;
+    } else if (value instanceof String || value instanceof Number || value instanceof Boolean) {
+      return true;
+    } else {
+      // dead code
+      Log.w(TAG, "Invalid value: " + value);
+      return false;
+    }
+  }
+}

--- a/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -4,6 +4,7 @@ import com.deploygate.sdk.internal.Logger;
 
 import org.json.JSONObject;
 
+import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
@@ -62,7 +63,22 @@ public final class CustomAttributes {
   }
 
   String toJsonString() {
-    return new JSONObject(attributes).toString();
+    return toJsonString("");
+  }
+
+  String toJsonString(String keyPrefix) {
+    synchronized (attributes) {
+      if (keyPrefix != null && !keyPrefix.isEmpty()) {
+        HashMap<String, Object> prefixedAttributes = new HashMap<>();
+        for (String key : attributes.keySet()) {
+          String prefixedKey = String.format("%s.%s", keyPrefix, key);
+          prefixedAttributes.put(prefixedKey, attributes.get(key));
+        }
+        return new JSONObject(prefixedAttributes).toString();
+      } else {
+        return new JSONObject(attributes).toString();
+      }
+    }
   }
 
   private boolean putInternal(String key, Object value) {

--- a/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -2,9 +2,6 @@ package com.deploygate.sdk;
 
 import com.deploygate.sdk.internal.Logger;
 
-import org.json.JSONObject;
-
-import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
@@ -16,7 +13,7 @@ public final class CustomAttributes {
   private static final Pattern VALID_KEY_PATTERN = Pattern.compile("^[a-z][_a-z0-9]{2,31}$");
   private static final int MAX_VALUE_LENGTH = 64;
 
-  private final ConcurrentHashMap<String, Object> attributes;
+  final ConcurrentHashMap<String, Object> attributes;
 
   CustomAttributes() {
     attributes = new ConcurrentHashMap<>();
@@ -60,25 +57,6 @@ public final class CustomAttributes {
 
   public boolean isEmpty() {
     return attributes.isEmpty();
-  }
-
-  String toJsonString() {
-    return toJsonString("");
-  }
-
-  String toJsonString(String keyPrefix) {
-    synchronized (attributes) {
-      if (keyPrefix != null && !keyPrefix.isEmpty()) {
-        HashMap<String, Object> prefixedAttributes = new HashMap<>();
-        for (String key : attributes.keySet()) {
-          String prefixedKey = String.format("%s.%s", keyPrefix, key);
-          prefixedAttributes.put(prefixedKey, attributes.get(key));
-        }
-        return new JSONObject(prefixedAttributes).toString();
-      } else {
-        return new JSONObject(attributes).toString();
-      }
-    }
   }
 
   private boolean putInternal(String key, Object value) {

--- a/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -1,6 +1,6 @@
 package com.deploygate.sdk;
 
-import android.util.Log;
+import com.deploygate.sdk.internal.Logger;
 
 import org.json.JSONObject;
 
@@ -82,17 +82,17 @@ public final class CustomAttributes {
 
   private boolean isValidKey(String key) {
     if (size() >= MAX_ATTRIBUTES_SIZE && !attributes.containsKey(key)) {
-      Log.w(TAG, "Attributes already reached max size. Ignored: " + key);
+      Logger.w(TAG, "Attributes already reached max size. Ignored: " + key);
       return false;
     }
 
     if (key == null || key.equals("true") || key.equals("false") || key.equals("null")) {
-      Log.w(TAG, "Not allowed key: " + key);
+      Logger.w(TAG, "Not allowed key: " + key);
       return false;
     }
 
     if (!VALID_KEY_PATTERN.matcher(key).matches()) {
-      Log.w(TAG, "Invalid key: " + key);
+      Logger.w(TAG, "Invalid key: " + key);
       return false;
     }
 
@@ -101,18 +101,18 @@ public final class CustomAttributes {
 
   private boolean isValidValue(Object value) {
     if (value == null) {
-      Log.w(TAG, "Value is null");
+      Logger.w(TAG, "Value is null");
       return false;
     }
 
     if (value instanceof String && ((String) value).length() > MAX_VALUE_LENGTH) {
-        Log.w(TAG, "Value too long: " + value);
+        Logger.w(TAG, "Value too long: " + value);
         return false;
     } else if (value instanceof String || value instanceof Number || value instanceof Boolean) {
       return true;
     } else {
       // dead code
-      Log.w(TAG, "Invalid value: " + value);
+      Logger.w(TAG, "Invalid value: " + value);
       return false;
     }
   }

--- a/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdk/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -66,16 +66,18 @@ public final class CustomAttributes {
   }
 
   private boolean putInternal(String key, Object value) {
-    if (!isValidKey(key)) {
-      return false;
-    }
+    synchronized (attributes) {
+      if (!isValidKey(key)) {
+        return false;
+      }
 
-    if (!isValidValue(value)) {
-      return false;
-    }
+      if (!isValidValue(value)) {
+        return false;
+      }
 
-    attributes.put(key, value);
-    return true;
+      attributes.put(key, value);
+      return true;
+    }
   }
 
   private boolean isValidKey(String key) {

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -53,8 +53,8 @@ public class DeployGate {
     private static final Object sPendingEventLock = new Object();
 
     private static final Object sLock = new Object();
-    private static CustomAttributes sBuildEnvironment = null;
-    private static CustomAttributes sRuntimeExtra = null;
+    private static CustomAttributes sBuildEnvironment;
+    private static CustomAttributes sRuntimeExtra;
 
     private static DeployGate sInstance;
 

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -147,8 +147,12 @@ public class DeployGate {
                 }
                 cv.put(DeployGateEvent.ATTRIBUTE_KEY_EVENT_AT, System.currentTimeMillis());
 
-                ContentResolver cr = mApplicationContext.getContentResolver();
-                cr.insert(targetUri, cv);
+                try {
+                    ContentResolver cr = mApplicationContext.getContentResolver();
+                    cr.insert(targetUri, cv);
+                } catch (Throwable t) {
+                    Logger.w(t, "failed to report device states");
+                }
             } else {
                 Logger.w("%s is not supported by this sdk version", action);
             }

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -143,7 +143,6 @@ public class DeployGate {
                 if (mRuntimeExtra != null) {
                     cv.put(DeployGateEvent.KEY_RUNTIME_EXTRAS, mRuntimeExtra.toJsonString());
                 }
-                cv.put(DeployGateEvent.KEY_PACKAGE_NAME, mApplicationContext.getPackageName());
                 cv.put(DeployGateEvent.KEY_EVENT_AT, System.currentTimeMillis());
 
                 ContentResolver cr = mApplicationContext.getContentResolver();

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -1390,4 +1390,140 @@ public class DeployGate {
 
         return sInstance.mDistributionUserName;
     }
+
+    public static boolean putBuildEnvironmentValue(String key, String value) {
+        if (sInstance != null) {
+            return sInstance.putBuildEnvironmentValueInternal(key, value);
+        }
+        return false;
+    }
+
+    public static boolean putBuildEnvironmentValue(String key, int value) {
+        if (sInstance != null) {
+            return sInstance.putBuildEnvironmentValueInternal(key, value);
+        }
+        return false;
+    }
+
+    public static boolean putBuildEnvironmentValue(String key, long value) {
+        if (sInstance != null) {
+            return sInstance.putBuildEnvironmentValueInternal(key, value);
+        }
+        return false;
+    }
+
+    public static boolean putBuildEnvironmentValue(String key, float value) {
+        if (sInstance != null) {
+            return sInstance.putBuildEnvironmentValueInternal(key, value);
+        }
+        return false;
+    }
+
+    public static boolean putBuildEnvironmentValue(String key, double value) {
+        if (sInstance != null) {
+            return sInstance.putBuildEnvironmentValueInternal(key, value);
+        }
+        return false;
+    }
+
+    public static boolean putBuildEnvironmentValue(String key, boolean value) {
+        if (sInstance != null) {
+            return sInstance.putBuildEnvironmentValueInternal(key, value);
+        }
+        return false;
+    }
+
+    public static void removeBuildEnvironmentValue(String key) {
+        if (sInstance != null) {
+            sInstance.removeBuildEnvironmentValueInternal(key);
+        }
+    }
+
+    public static void removeAllBuildEnvironmentValues() {
+        if (sInstance != null) {
+            sInstance.removeAllBuildEnvironmentValuesInternal();
+        }
+    }
+
+    public static boolean putRuntimeExtraValue(String key, String value) {
+        if (sInstance != null) {
+            return sInstance.putRuntimeExtraValueInternal(key, value);
+        }
+        return false;
+    }
+
+    public static boolean putRuntimeExtraValue(String key, int value) {
+        if (sInstance != null) {
+            return sInstance.putRuntimeExtraValueInternal(key, value);
+        }
+        return false;
+    }
+
+    public static boolean putRuntimeExtraValue(String key, long value) {
+        if (sInstance != null) {
+            return sInstance.putRuntimeExtraValueInternal(key, value);
+        }
+        return false;
+    }
+
+    public static boolean putRuntimeExtraValue(String key, float value) {
+        if (sInstance != null) {
+            return sInstance.putRuntimeExtraValueInternal(key, value);
+        }
+        return false;
+    }
+
+    public static boolean putRuntimeExtraValue(String key, double value) {
+        if (sInstance != null) {
+            return sInstance.putRuntimeExtraValueInternal(key, value);
+        }
+        return false;
+    }
+
+    public static boolean putRuntimeExtraValue(String key, boolean value) {
+        if (sInstance != null) {
+            return sInstance.putRuntimeExtraValueInternal(key, value);
+        }
+        return false;
+    }
+
+    public static void removeRuntimeExtraValue(String key) {
+        if (sInstance != null) {
+            sInstance.removeRuntimeExtraValueInternal(key);
+        }
+    }
+
+    public static void removeAllRuntimeExtraValues() {
+        if (sInstance != null) {
+            sInstance.removeAllRuntimeExtraValuesInternal();
+        }
+    }
+
+    private boolean putBuildEnvironmentValueInternal(String key, Object value) {
+        return true;
+    }
+
+    private void removeBuildEnvironmentValueInternal(String key) {
+    }
+
+    private void removeAllBuildEnvironmentValuesInternal() {
+    }
+
+    private boolean putRuntimeExtraValueInternal(String key, Object value) {
+        return true;
+    }
+
+    private void removeRuntimeExtraValueInternal(String key) {
+    }
+
+    private void removeAllRuntimeExtraValuesInternal() {
+    }
+
+    private boolean isValidKey(String key) {
+        return true;
+    }
+
+    private boolean isValidValue(Object value) {
+        return true;
+    }
 }

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -3,10 +3,13 @@ package com.deploygate.sdk;
 import android.app.Application;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
+import android.content.ContentResolver;
+import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -129,6 +132,18 @@ public class DeployGate {
                 } else {
                     Logger.w("streamed logcat is not supported");
                 }
+            } else if (DeployGateEvent.ACTION_COLLECT_DEVICE_STATES.equals(action)) {
+                Uri targetUri = Uri.parse(extras.getString(DeployGateEvent.EXTRA_TARGET_URI_FOR_REPORT_DEVICE_STATES));
+                Logger.d("collect-device-status event received: %s", targetUri);
+
+                ContentValues cv = new ContentValues();
+                cv.put(DeployGateEvent.KEY_BUILD_ENVIRONMENT, mBuildEnvironment.toJsonString());
+                cv.put(DeployGateEvent.KEY_RUNTIME_EXTRAS, mRuntimeExtra.toJsonString());
+                cv.put(DeployGateEvent.KEY_PACKAGE_NAME, mApplicationContext.getPackageName());
+                cv.put(DeployGateEvent.KEY_EVENT_AT, System.currentTimeMillis());
+
+                ContentResolver cr = mApplicationContext.getContentResolver();
+                cr.insert(targetUri, cv);
             } else {
                 Logger.w("%s is not supported by this sdk version", action);
             }

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -140,12 +140,12 @@ public class DeployGate {
 
                 ContentValues cv = new ContentValues();
                 if (sBuildEnvironment != null && !sBuildEnvironment.isEmpty()) {
-                    cv.put(DeployGateEvent.KEY_BUILD_ENVIRONMENT, sBuildEnvironment.toJsonString());
+                    cv.put(DeployGateEvent.ATTRIBUTE_KEY_BUILD_ENVIRONMENT, sBuildEnvironment.toJsonString());
                 }
                 if (sRuntimeExtra != null && !sRuntimeExtra.isEmpty()) {
-                    cv.put(DeployGateEvent.KEY_RUNTIME_EXTRAS, sRuntimeExtra.toJsonString());
+                    cv.put(DeployGateEvent.ATTRIBUTE_KEY_RUNTIME_EXTRAS, sRuntimeExtra.toJsonString());
                 }
-                cv.put(DeployGateEvent.KEY_EVENT_AT, System.currentTimeMillis());
+                cv.put(DeployGateEvent.ATTRIBUTE_KEY_EVENT_AT, System.currentTimeMillis());
 
                 ContentResolver cr = mApplicationContext.getContentResolver();
                 cr.insert(targetUri, cv);

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -57,7 +57,7 @@ public class DeployGate {
     private static final Object sLock = new Object();
     private static CustomAttributes sBuildEnvironment;
     private static CustomAttributes sRuntimeExtra;
-    private static CustomAttributes sSdkRuntimeExtra;
+    private static CustomAttributes sSdkDeviceStates;
 
     private static DeployGate sInstance;
 
@@ -153,9 +153,9 @@ public class DeployGate {
                     cv.put(DeployGateEvent.ATTRIBUTE_KEY_RUNTIME_EXTRAS, runtimeExtraJSON);
                 }
 
-                if (!mergedRuntimeExtraHashMap.isEmpty()) {
-                    String runtimeExtraJson = new JSONObject(mergedRuntimeExtraHashMap).toString();
-                    cv.put(DeployGateEvent.ATTRIBUTE_KEY_RUNTIME_EXTRAS, runtimeExtraJson);
+                String sdkDeviceStatusJSON = getSdkDeviceStates().getJSONString();
+                if (!sdkDeviceStatusJSON.equals("{}")) {
+                    cv.put(DeployGateEvent.ATTRIBUTE_KEY_SDK_DEVICE_STATES, sdkDeviceStatusJSON);
                 }
 
                 cv.put(DeployGateEvent.ATTRIBUTE_KEY_EVENT_AT, System.currentTimeMillis());
@@ -1460,18 +1460,18 @@ public class DeployGate {
         return sRuntimeExtra;
     }
 
-    private static CustomAttributes getSdkRuntimeExtra() {
-        if (sSdkRuntimeExtra != null) {
-            return sSdkRuntimeExtra;
+    private static CustomAttributes getSdkDeviceStates() {
+        if (sSdkDeviceStates != null) {
+            return sSdkDeviceStates;
         }
 
         synchronized (sLock) {
-            if (sSdkRuntimeExtra != null) {
-                return sSdkRuntimeExtra;
+            if (sSdkDeviceStates != null) {
+                return sSdkDeviceStates;
             }
-            sSdkRuntimeExtra = new CustomAttributes();
+            sSdkDeviceStates = new CustomAttributes();
         }
 
-        return sSdkRuntimeExtra;
+        return sSdkDeviceStates;
     }
 }

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -137,8 +137,12 @@ public class DeployGate {
                 Logger.d("collect-device-status event received: %s", targetUri);
 
                 ContentValues cv = new ContentValues();
-                cv.put(DeployGateEvent.KEY_BUILD_ENVIRONMENT, mBuildEnvironment.toJsonString());
-                cv.put(DeployGateEvent.KEY_RUNTIME_EXTRAS, mRuntimeExtra.toJsonString());
+                if (mBuildEnvironment != null) {
+                    cv.put(DeployGateEvent.KEY_BUILD_ENVIRONMENT, mBuildEnvironment.toJsonString());
+                }
+                if (mRuntimeExtra != null) {
+                    cv.put(DeployGateEvent.KEY_RUNTIME_EXTRAS, mRuntimeExtra.toJsonString());
+                }
                 cv.put(DeployGateEvent.KEY_PACKAGE_NAME, mApplicationContext.getPackageName());
                 cv.put(DeployGateEvent.KEY_EVENT_AT, System.currentTimeMillis());
 

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -28,6 +28,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 /**
  * This is DeployGate SDK library. Import this library to the application

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -139,12 +139,17 @@ public class DeployGate {
                 Logger.d("collect-device-status event received: %s", targetUri);
 
                 ContentValues cv = new ContentValues();
-                if (sBuildEnvironment != null && !sBuildEnvironment.isEmpty()) {
-                    cv.put(DeployGateEvent.ATTRIBUTE_KEY_BUILD_ENVIRONMENT, sBuildEnvironment.toJsonString());
+                String buildEnvironmentJson = getBuildEnvironment().toJsonString();
+                if (!buildEnvironmentJson.equals("{}")) {
+                    cv.put(DeployGateEvent.ATTRIBUTE_KEY_BUILD_ENVIRONMENT, buildEnvironmentJson);
                 }
-                if (sRuntimeExtra != null && !sRuntimeExtra.isEmpty()) {
-                    cv.put(DeployGateEvent.ATTRIBUTE_KEY_RUNTIME_EXTRAS, sRuntimeExtra.toJsonString());
+
+                // attribute keys of runtime extra need to prefix with the package name
+                String runtimeExtraJson = getRuntimeExtra().toJsonString(mHostApp.packageName);
+                if (!runtimeExtraJson.equals("{}")) {
+                    cv.put(DeployGateEvent.ATTRIBUTE_KEY_RUNTIME_EXTRAS, runtimeExtraJson);
                 }
+
                 cv.put(DeployGateEvent.ATTRIBUTE_KEY_EVENT_AT, System.currentTimeMillis());
 
                 try {

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -8,6 +8,7 @@ public interface DeployGateEvent {
     // namespace:
     //   ACTION => a
     //   EXTRA => e
+    //   KEY => k
     //
     // content:
     //   should be hyphen-separated string and be lower cases
@@ -26,6 +27,11 @@ public interface DeployGateEvent {
     public static final String ACTION_OPEN_COMMENTS = "openComments";
     public static final String ACTION_COMPOSE_COMMENT = "composeComment";
     public static final String ACTION_VISIBILITY_EVENT = "a.visibility-event";
+
+    /**
+     * @since 4.8.0
+     */
+    public static final String ACTION_COLLECT_DEVICE_STATES = "a.collect-device-states";
 
     public static final String EXTRA_AUTHOR = "author";
     public static final String EXTRA_EXPECTED_AUTHOR = "expectedAuthor";
@@ -120,6 +126,31 @@ public interface DeployGateEvent {
      * this value must be nano times.
      */
     public static final String EXTRA_VISIBILITY_EVENT_ELAPSED_REAL_TIME_IN_NANOS = "e.visibility-event-elapsed-real-time";
+
+    /**
+     * @since 4.8.0
+     */
+    public static final String EXTRA_TARGET_URI_FOR_REPORT_DEVICE_STATES = "e.target-uri-for-report-device-states";
+
+    /**
+     * @since 4.8.0
+     */
+    public static final String KEY_BUILD_ENVIRONMENT = "k.build-environment";
+
+    /**
+     * @since 4.8.0
+     */
+    public static final String KEY_RUNTIME_EXTRAS = "k.runtime-extras";
+
+    /**
+     * @since 4.8.0
+     */
+    public static final String KEY_PACKAGE_NAME = "k.package-name";
+
+    /**
+     * @since 4.8.0
+     */
+    public static final String KEY_EVENT_AT = "k.event-at";
 
     interface VisibilityType {
         int BACKGROUND = 0;

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -8,7 +8,7 @@ public interface DeployGateEvent {
     // namespace:
     //   ACTION => a
     //   EXTRA => e
-    //   KEY => k
+    //   ATTRIBUTE_KEY => ak
     //
     // content:
     //   should be hyphen-separated string and be lower cases
@@ -135,22 +135,17 @@ public interface DeployGateEvent {
     /**
      * @since 4.8.0
      */
-    public static final String KEY_BUILD_ENVIRONMENT = "k.build-environment";
+    public static final String ATTRIBUTE_KEY_BUILD_ENVIRONMENT = "ak.build-environment";
 
     /**
      * @since 4.8.0
      */
-    public static final String KEY_RUNTIME_EXTRAS = "k.runtime-extras";
+    public static final String ATTRIBUTE_KEY_RUNTIME_EXTRAS = "ak.runtime-extras";
 
     /**
      * @since 4.8.0
      */
-    public static final String KEY_PACKAGE_NAME = "k.package-name";
-
-    /**
-     * @since 4.8.0
-     */
-    public static final String KEY_EVENT_AT = "k.event-at";
+    public static final String ATTRIBUTE_KEY_EVENT_AT = "ak.event-at";
 
     interface VisibilityType {
         int BACKGROUND = 0;

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -145,6 +145,11 @@ public interface DeployGateEvent {
     /**
      * @since 4.8.0
      */
+    public static final String ATTRIBUTE_KEY_SDK_DEVICE_STATES = "ak.sdk-device-states";
+
+    /**
+     * @since 4.8.0
+     */
     public static final String ATTRIBUTE_KEY_EVENT_AT = "ak.event-at";
 
     interface VisibilityType {

--- a/sdk/src/test/java/com/deploygate/sdk/CustomAttributesInterfaceTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CustomAttributesInterfaceTest.java
@@ -1,0 +1,68 @@
+package com.deploygate.sdk;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * This test class will make sure all *public* interfaces are defined as expected
+ */
+@RunWith(AndroidJUnit4.class)
+public class CustomAttributesInterfaceTest {
+
+  @NonNull
+  CustomAttributes attributes;
+
+  @Before
+  public void setUp() {
+    attributes = new CustomAttributes();
+  }
+
+  @Test
+  public void putString() {
+    attributes.putString("key", "value");
+  }
+
+  @Test
+  public void putInt() {
+    attributes.putInt("key", 1);
+  }
+
+  @Test
+  public void putLong() {
+    attributes.putLong("key", 1L);
+  }
+
+  @Test
+  public void putFloat() {
+    attributes.putFloat("key", 1.0f);
+  }
+
+  @Test
+  public void putDouble() {
+    attributes.putDouble("key", 1.0);
+  }
+
+  public void putBoolean() {
+    attributes.putBoolean("key", true);
+  }
+
+  public void remove() {
+    attributes.remove("key");
+  }
+
+  public void removeAll() {
+    attributes.removeAll();
+  }
+
+  public int size() {
+    return attributes.size();
+  }
+
+  public boolean isEmpty() {
+    return attributes.isEmpty();
+  }
+}

--- a/sdk/src/test/java/com/deploygate/sdk/CustomAttributesInterfaceTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CustomAttributesInterfaceTest.java
@@ -3,6 +3,8 @@ package com.deploygate.sdk;
 import androidx.annotation.NonNull;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.google.common.truth.Truth;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,46 +25,51 @@ public class CustomAttributesInterfaceTest {
 
   @Test
   public void putString() {
-    attributes.putString("key", "value");
+    Truth.assertThat(attributes.putString("key", "value")).isInstanceOf(Boolean.class);
   }
 
   @Test
   public void putInt() {
-    attributes.putInt("key", 1);
+    Truth.assertThat(attributes.putInt("key", 1)).isInstanceOf(Boolean.class);
   }
 
   @Test
   public void putLong() {
-    attributes.putLong("key", 1L);
+    Truth.assertThat(attributes.putLong("key", 1L)).isInstanceOf(Boolean.class);
   }
 
   @Test
   public void putFloat() {
-    attributes.putFloat("key", 1.0f);
+    Truth.assertThat(attributes.putFloat("key", 1.0f)).isInstanceOf(Boolean.class);
   }
 
   @Test
   public void putDouble() {
-    attributes.putDouble("key", 1.0);
+    Truth.assertThat(attributes.putDouble("key", 1.0)).isInstanceOf(Boolean.class);
   }
 
+  @Test
   public void putBoolean() {
-    attributes.putBoolean("key", true);
+    Truth.assertThat(attributes.putBoolean("key", true)).isInstanceOf(Boolean.class);
   }
 
+  @Test
   public void remove() {
     attributes.remove("key");
   }
 
+  @Test
   public void removeAll() {
     attributes.removeAll();
   }
 
-  public int size() {
-    return attributes.size();
+  @Test
+  public void size() {
+    Truth.assertThat(attributes.size()).isInstanceOf(Integer.class);
   }
 
-  public boolean isEmpty() {
-    return attributes.isEmpty();
+  @Test
+  public void isEmpty() {
+    Truth.assertThat(attributes.isEmpty()).isInstanceOf(Boolean.class);
   }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/CustomAttributesInterfaceTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CustomAttributesInterfaceTest.java
@@ -62,14 +62,4 @@ public class CustomAttributesInterfaceTest {
   public void removeAll() {
     attributes.removeAll();
   }
-
-  @Test
-  public void size() {
-    Truth.assertThat(attributes.size()).isInstanceOf(Integer.class);
-  }
-
-  @Test
-  public void isEmpty() {
-    Truth.assertThat(attributes.isEmpty()).isInstanceOf(Boolean.class);
-  }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/CustomAttributesTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CustomAttributesTest.java
@@ -22,26 +22,26 @@ public class CustomAttributesTest {
 
   @Test
   public void put__accept_when_valid_key() {
-    Truth.assertThat(attributes.putString("valid", "value")).isTrue();
-    Truth.assertThat(attributes.putString("valid_underscore", "value")).isTrue();
-    Truth.assertThat(attributes.putString("valid_1_number", "value")).isTrue();
-    Truth.assertThat(attributes.putString("min", "value")).isTrue();
-    Truth.assertThat(attributes.putString("valid_key_with_length_under_32", "value")).isTrue();
+    Truth.assertThat(attributes.putString("valid", "valid_value1")).isTrue();
+    Truth.assertThat(attributes.putString("valid_underscore", "valid_value2")).isTrue();
+    Truth.assertThat(attributes.putString("valid_1_number", "valid_value3")).isTrue();
+    Truth.assertThat(attributes.putString("min", "valid_value4")).isTrue();
+    Truth.assertThat(attributes.putString("valid_key_with_length_under_32", "valid_value5")).isTrue();
 
-    Truth.assertThat(attributes.putString("ng", "value")).isFalse();
-    Truth.assertThat(attributes.putString("true", "value")).isFalse();
-    Truth.assertThat(attributes.putString("false", "value")).isFalse();
-    Truth.assertThat(attributes.putString("null", "value")).isFalse();
-    Truth.assertThat(attributes.putString("invalid-hyphen", "value")).isFalse();
-    Truth.assertThat(attributes.putString("invalid#sharp", "value")).isFalse();
-    Truth.assertThat(attributes.putString("invalid$dollar", "value")).isFalse();
-    Truth.assertThat(attributes.putString("invalid.dot", "value")).isFalse();
-    Truth.assertThat(attributes.putString("invalid!bang", "value")).isFalse();
-    Truth.assertThat(attributes.putString("invalid*glob", "value")).isFalse();
-    Truth.assertThat(attributes.putString("invalidUpperCase", "value")).isFalse();
-    Truth.assertThat(attributes.putString("12345", "value")).isFalse();
-    Truth.assertThat(attributes.putString("1_invalid_begin_number", "value")).isFalse();
-    Truth.assertThat(attributes.putString("invalid_key_with_length_over_32_characters", "value")).isFalse();
+    Truth.assertThat(attributes.putString("ng", "invalid_value1")).isFalse();
+    Truth.assertThat(attributes.putString("true", "invalid_value2")).isFalse();
+    Truth.assertThat(attributes.putString("false", "invalid_value3")).isFalse();
+    Truth.assertThat(attributes.putString("null", "invalid_value4")).isFalse();
+    Truth.assertThat(attributes.putString("invalid-hyphen", "invalid_value5")).isFalse();
+    Truth.assertThat(attributes.putString("invalid#sharp", "invalid_value6")).isFalse();
+    Truth.assertThat(attributes.putString("invalid$dollar", "invalid_value7")).isFalse();
+    Truth.assertThat(attributes.putString("invalid.dot", "invalid_value8")).isFalse();
+    Truth.assertThat(attributes.putString("invalid!bang", "invalid_value9")).isFalse();
+    Truth.assertThat(attributes.putString("invalid*glob", "invalid_value10")).isFalse();
+    Truth.assertThat(attributes.putString("invalidUpperCase", "invalid_value11")).isFalse();
+    Truth.assertThat(attributes.putString("12345", "invalid_value12")).isFalse();
+    Truth.assertThat(attributes.putString("1_invalid_begin_number", "invalid_value13")).isFalse();
+    Truth.assertThat(attributes.putString("invalid_key_with_length_over_32_characters", "invalid_value14")).isFalse();
   }
 
   @Test
@@ -58,60 +58,63 @@ public class CustomAttributesTest {
 
   @Test
   public void not_exceed_max_size() {
-    Truth.assertThat(attributes.putString("key1", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key2", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key3", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key4", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key5", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key6", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key7", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key8", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key1", "value1")).isTrue();
+    Truth.assertThat(attributes.putString("key2", "value2")).isTrue();
+    Truth.assertThat(attributes.putString("key3", "value3")).isTrue();
+    Truth.assertThat(attributes.putString("key4", "value4")).isTrue();
+    Truth.assertThat(attributes.putString("key5", "value5")).isTrue();
+    Truth.assertThat(attributes.putString("key6", "value6")).isTrue();
+    Truth.assertThat(attributes.putString("key7", "value7")).isTrue();
+    Truth.assertThat(attributes.putString("key8", "value8")).isTrue();
 
     // allow to overwrite
-    Truth.assertThat(attributes.putString("key1", "value2")).isTrue();
+    Truth.assertThat(attributes.putString("key1", "overwrite1_1")).isTrue();
     // not allow to put value with new key because of max size
-    Truth.assertThat(attributes.putString("key9", "value")).isFalse();
+    Truth.assertThat(attributes.putString("key9", "value9")).isFalse();
 
     attributes.remove("key8");
 
     // allow to put value with new key after remove exists key
-    Truth.assertThat(attributes.putString("key9", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key9", "value9")).isTrue();
     // allow to overwrite
-    Truth.assertThat(attributes.putString("key1", "value3")).isTrue();
+    Truth.assertThat(attributes.putString("key1", "overwrite1_2")).isTrue();
     // not allow to put value with new key because of max size
-    Truth.assertThat(attributes.putString("key10", "value")).isFalse();
+    Truth.assertThat(attributes.putString("key10", "value10")).isFalse();
 
     attributes.removeAll();
 
     // allow to put value less than max size
-    Truth.assertThat(attributes.putString("key1", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key2", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key3", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key4", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key5", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key6", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key7", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key8", "value")).isTrue();
-    Truth.assertThat(attributes.putString("key9", "value")).isFalse();
+    Truth.assertThat(attributes.putString("key1", "another_value1")).isTrue();
+    Truth.assertThat(attributes.putString("key2", "another_value2")).isTrue();
+    Truth.assertThat(attributes.putString("key3", "another_value3")).isTrue();
+    Truth.assertThat(attributes.putString("key4", "another_value4")).isTrue();
+    Truth.assertThat(attributes.putString("key5", "another_value5")).isTrue();
+    Truth.assertThat(attributes.putString("key6", "another_value6")).isTrue();
+    Truth.assertThat(attributes.putString("key7", "another_value7")).isTrue();
+    Truth.assertThat(attributes.putString("key8", "another_value8")).isTrue();
+    Truth.assertThat(attributes.putString("key9", "another_value9")).isFalse();
   }
 
   @Test
   public void size() {
     Truth.assertThat(attributes.size()).isEqualTo(0);
 
-    attributes.putString("key1", "value");
+    attributes.putString("key1", "value1");
     Truth.assertThat(attributes.size()).isEqualTo(1);
 
-    attributes.putString("key2", "value");
-    attributes.putString("key3", "value");
-    attributes.putString("key4", "value");
-    attributes.putString("key5", "value");
-    attributes.putString("key6", "value");
-    attributes.putString("key7", "value");
-    attributes.putString("key8", "value");
+    attributes.putString("key1", "overwrite1");
+    Truth.assertThat(attributes.size()).isEqualTo(1);
+
+    attributes.putString("key2", "value2");
+    attributes.putString("key3", "value3");
+    attributes.putString("key4", "value4");
+    attributes.putString("key5", "value5");
+    attributes.putString("key6", "value6");
+    attributes.putString("key7", "value7");
+    attributes.putString("key8", "value8");
     Truth.assertThat(attributes.size()).isEqualTo(8);
 
-    attributes.putString("key9", "value");
+    attributes.putString("key9", "value9");
     Truth.assertThat(attributes.size()).isEqualTo(8);
 
     attributes.remove("key1");
@@ -125,11 +128,14 @@ public class CustomAttributesTest {
   public void isEmpty() {
     Truth.assertThat(attributes.isEmpty()).isTrue();
 
-    attributes.putString("key1", "value");
+    attributes.putString("key1", "value1");
     Truth.assertThat(attributes.isEmpty()).isFalse();
 
-    attributes.putString("key2", "value");
-    attributes.putString("key3", "value");
+    attributes.putString("key1", "overwrite1");
+    Truth.assertThat(attributes.isEmpty()).isFalse();
+
+    attributes.putString("key2", "value2");
+    attributes.putString("key3", "value3");
     Truth.assertThat(attributes.isEmpty()).isFalse();
 
     attributes.remove("key1");
@@ -138,7 +144,7 @@ public class CustomAttributesTest {
     attributes.removeAll();
     Truth.assertThat(attributes.isEmpty()).isTrue();
 
-    attributes.putString("key4", "value");
+    attributes.putString("key4", "value4");
     Truth.assertThat(attributes.isEmpty()).isFalse();
   }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/CustomAttributesTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CustomAttributesTest.java
@@ -90,6 +90,46 @@ public class CustomAttributesTest {
   }
 
   @Test
+  public void toJSONString() {
+    Truth.assertThat(attributes.getJSONString()).isEqualTo("{}");
+
+    attributes.putString("string", "value");
+    attributes.putInt("int", Integer.MAX_VALUE);
+    attributes.putLong("long", Long.MAX_VALUE);
+    attributes.putFloat("float", Float.MAX_VALUE);
+    attributes.putDouble("double", Double.MAX_VALUE);
+    attributes.putBoolean("boolean", true);
+
+    String expectedJSON = "{" +
+        "\"string\":\"value\"," +
+        "\"int\":2147483647," +
+        "\"long\":9223372036854775807," +
+        "\"float\":3.4028235E38," +
+        "\"double\":1.7976931348623157E308," +
+        "\"boolean\":true" +
+        "}";
+    Truth.assertThat(attributes.getJSONString()).isEqualTo(expectedJSON);
+
+    attributes.removeAll();
+    attributes.putString("string2", "value2");
+    attributes.putInt("int2", Integer.MIN_VALUE);
+    attributes.putLong("long2", Long.MIN_VALUE);
+    attributes.putFloat("float2", Float.MIN_VALUE);
+    attributes.putDouble("double2", Double.MIN_VALUE);
+    attributes.putBoolean("boolean2", false);
+
+    String expectedJSON2 = "{" +
+        "\"string2\":\"value2\"," +
+        "\"int2\":-2147483648," +
+        "\"long2\":-9223372036854775808," +
+        "\"float2\":1.4E-45," +
+        "\"double2\":4.9E-324," +
+        "\"boolean2\":false" +
+        "}";
+    Truth.assertThat(attributes.getJSONString()).isEqualTo(expectedJSON2);
+  }
+
+  @Test
   public void not_exceed_max_size() {
     Truth.assertThat(attributes.putString("key1", "value1")).isTrue();
     Truth.assertThat(attributes.putString("key2", "value2")).isTrue();

--- a/sdk/src/test/java/com/deploygate/sdk/CustomAttributesTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CustomAttributesTest.java
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.google.common.truth.Truth;
 
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,7 +22,7 @@ public class CustomAttributesTest {
   }
 
   @Test
-  public void put__key_pattern() {
+  public void put__keyPattern() {
     Truth.assertThat(attributes.putString("valid", "value")).isTrue();
     Truth.assertThat(attributes.putString("valid_underscore", "value")).isTrue();
     Truth.assertThat(attributes.putString("valid_1_number", "value")).isTrue();
@@ -45,7 +46,7 @@ public class CustomAttributesTest {
   }
 
   @Test
-  public void put__value_pattern() {
+  public void put__valuePattern() {
     Truth.assertThat(attributes.putString("valid_string", "value")).isTrue();
     Truth.assertThat(attributes.putInt("valid_int", 1)).isTrue();
     Truth.assertThat(attributes.putLong("valid_long", 1L)).isTrue();
@@ -57,7 +58,7 @@ public class CustomAttributesTest {
   }
 
   @Test
-  public void put__max_size() {
+  public void put_remove_removeAll_maxSize() {
     Truth.assertThat(attributes.putString("key1", "value")).isTrue();
     Truth.assertThat(attributes.putString("key2", "value")).isTrue();
     Truth.assertThat(attributes.putString("key3", "value")).isTrue();
@@ -93,5 +94,27 @@ public class CustomAttributesTest {
     Truth.assertThat(attributes.putString("key7", "value")).isTrue();
     Truth.assertThat(attributes.putString("key8", "value")).isTrue();
     Truth.assertThat(attributes.putString("key9", "value")).isFalse();
+  }
+
+  @Test
+  public void toJsonString() {
+    attributes.putString("valid_string", "value");
+    attributes.putInt("valid_int", 1);
+    attributes.putLong("valid_long", 1L);
+    attributes.putFloat("valid_float", 1.1f);
+    attributes.putDouble("valid_double", 1.1);
+    attributes.putBoolean("valid_boolean", true);
+
+    try {
+      JSONObject actualJson = new JSONObject(attributes.toJsonString());
+      Truth.assertThat(actualJson.getString("valid_string")).isEqualTo("value");
+      Truth.assertThat(actualJson.getInt("valid_int")).isEqualTo(1);
+      Truth.assertThat(actualJson.getLong("valid_long")).isEqualTo(1L);
+      Truth.assertThat((float) actualJson.getDouble("valid_float")).isEqualTo(1.1f);
+      Truth.assertThat(actualJson.getDouble("valid_double")).isEqualTo(1.1);
+      Truth.assertThat(actualJson.getBoolean("valid_boolean")).isTrue();
+    } catch (Exception e) {
+      Truth.assertWithMessage("Failed to parse JSON").fail();
+    }
   }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/CustomAttributesTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CustomAttributesTest.java
@@ -22,7 +22,7 @@ public class CustomAttributesTest {
   }
 
   @Test
-  public void put__keyPattern() {
+  public void put__accept_when_valid_key() {
     Truth.assertThat(attributes.putString("valid", "value")).isTrue();
     Truth.assertThat(attributes.putString("valid_underscore", "value")).isTrue();
     Truth.assertThat(attributes.putString("valid_1_number", "value")).isTrue();
@@ -46,7 +46,7 @@ public class CustomAttributesTest {
   }
 
   @Test
-  public void put__valuePattern() {
+  public void put__accept_when_valid_value() {
     Truth.assertThat(attributes.putString("valid_string", "value")).isTrue();
     Truth.assertThat(attributes.putInt("valid_int", 1)).isTrue();
     Truth.assertThat(attributes.putLong("valid_long", 1L)).isTrue();
@@ -58,7 +58,7 @@ public class CustomAttributesTest {
   }
 
   @Test
-  public void put_remove_removeAll_maxSize() {
+  public void not_exceed_max_size() {
     Truth.assertThat(attributes.putString("key1", "value")).isTrue();
     Truth.assertThat(attributes.putString("key2", "value")).isTrue();
     Truth.assertThat(attributes.putString("key3", "value")).isTrue();

--- a/sdk/src/test/java/com/deploygate/sdk/CustomAttributesTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CustomAttributesTest.java
@@ -97,6 +97,53 @@ public class CustomAttributesTest {
   }
 
   @Test
+  public void size() {
+    Truth.assertThat(attributes.size()).isEqualTo(0);
+
+    attributes.putString("key1", "value");
+    Truth.assertThat(attributes.size()).isEqualTo(1);
+
+    attributes.putString("key2", "value");
+    attributes.putString("key3", "value");
+    attributes.putString("key4", "value");
+    attributes.putString("key5", "value");
+    attributes.putString("key6", "value");
+    attributes.putString("key7", "value");
+    attributes.putString("key8", "value");
+    Truth.assertThat(attributes.size()).isEqualTo(8);
+
+    attributes.putString("key9", "value");
+    Truth.assertThat(attributes.size()).isEqualTo(8);
+
+    attributes.remove("key1");
+    Truth.assertThat(attributes.size()).isEqualTo(7);
+
+    attributes.removeAll();
+    Truth.assertThat(attributes.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void isEmpty() {
+    Truth.assertThat(attributes.isEmpty()).isTrue();
+
+    attributes.putString("key1", "value");
+    Truth.assertThat(attributes.isEmpty()).isFalse();
+
+    attributes.putString("key2", "value");
+    attributes.putString("key3", "value");
+    Truth.assertThat(attributes.isEmpty()).isFalse();
+
+    attributes.remove("key1");
+    Truth.assertThat(attributes.isEmpty()).isFalse();
+
+    attributes.removeAll();
+    Truth.assertThat(attributes.isEmpty()).isTrue();
+
+    attributes.putString("key4", "value");
+    Truth.assertThat(attributes.isEmpty()).isFalse();
+  }
+
+  @Test
   public void toJsonString() {
     attributes.putString("valid_string", "value");
     attributes.putInt("valid_int", 1);

--- a/sdk/src/test/java/com/deploygate/sdk/CustomAttributesTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CustomAttributesTest.java
@@ -1,0 +1,97 @@
+package com.deploygate.sdk;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.google.common.truth.Truth;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class CustomAttributesTest {
+
+  @NonNull
+  CustomAttributes attributes;
+
+  @Before
+  public void setUp() {
+    attributes = new CustomAttributes();
+  }
+
+  @Test
+  public void put__key_pattern() {
+    Truth.assertThat(attributes.putString("valid", "value")).isTrue();
+    Truth.assertThat(attributes.putString("valid_underscore", "value")).isTrue();
+    Truth.assertThat(attributes.putString("valid_1_number", "value")).isTrue();
+    Truth.assertThat(attributes.putString("min", "value")).isTrue();
+    Truth.assertThat(attributes.putString("valid_key_with_length_under_32", "value")).isTrue();
+
+    Truth.assertThat(attributes.putString("ng", "value")).isFalse();
+    Truth.assertThat(attributes.putString("true", "value")).isFalse();
+    Truth.assertThat(attributes.putString("false", "value")).isFalse();
+    Truth.assertThat(attributes.putString("null", "value")).isFalse();
+    Truth.assertThat(attributes.putString("invalid-hyphen", "value")).isFalse();
+    Truth.assertThat(attributes.putString("invalid#sharp", "value")).isFalse();
+    Truth.assertThat(attributes.putString("invalid$dollar", "value")).isFalse();
+    Truth.assertThat(attributes.putString("invalid.dot", "value")).isFalse();
+    Truth.assertThat(attributes.putString("invalid!bang", "value")).isFalse();
+    Truth.assertThat(attributes.putString("invalid*glob", "value")).isFalse();
+    Truth.assertThat(attributes.putString("invalidUpperCase", "value")).isFalse();
+    Truth.assertThat(attributes.putString("12345", "value")).isFalse();
+    Truth.assertThat(attributes.putString("1_invalid_begin_number", "value")).isFalse();
+    Truth.assertThat(attributes.putString("invalid_key_with_length_over_32_characters", "value")).isFalse();
+  }
+
+  @Test
+  public void put__value_pattern() {
+    Truth.assertThat(attributes.putString("valid_string", "value")).isTrue();
+    Truth.assertThat(attributes.putInt("valid_int", 1)).isTrue();
+    Truth.assertThat(attributes.putLong("valid_long", 1L)).isTrue();
+    Truth.assertThat(attributes.putFloat("valid_float", 1.1f)).isTrue();
+    Truth.assertThat(attributes.putDouble("valid_double", 1.1)).isTrue();
+    Truth.assertThat(attributes.putBoolean("valid_boolean", true)).isTrue();
+
+    Truth.assertThat(attributes.putString("invalid_too_long_string", "this is too long string value. we cannot accept value if size over 64.")).isFalse();
+  }
+
+  @Test
+  public void put__max_size() {
+    Truth.assertThat(attributes.putString("key1", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key2", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key3", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key4", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key5", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key6", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key7", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key8", "value")).isTrue();
+
+    // allow to overwrite
+    Truth.assertThat(attributes.putString("key1", "value2")).isTrue();
+    // not allow to put value with new key because of max size
+    Truth.assertThat(attributes.putString("key9", "value")).isFalse();
+
+    attributes.remove("key8");
+
+    // allow to put value with new key after remove exists key
+    Truth.assertThat(attributes.putString("key9", "value")).isTrue();
+    // allow to overwrite
+    Truth.assertThat(attributes.putString("key1", "value3")).isTrue();
+    // not allow to put value with new key because of max size
+    Truth.assertThat(attributes.putString("key10", "value")).isFalse();
+
+    attributes.removeAll();
+
+    // allow to put value less than max size
+    Truth.assertThat(attributes.putString("key1", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key2", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key3", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key4", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key5", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key6", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key7", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key8", "value")).isTrue();
+    Truth.assertThat(attributes.putString("key9", "value")).isFalse();
+  }
+}

--- a/sdk/src/test/java/com/deploygate/sdk/CustomAttributesTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/CustomAttributesTest.java
@@ -5,7 +5,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.google.common.truth.Truth;
 
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -141,27 +140,5 @@ public class CustomAttributesTest {
 
     attributes.putString("key4", "value");
     Truth.assertThat(attributes.isEmpty()).isFalse();
-  }
-
-  @Test
-  public void toJsonString() {
-    attributes.putString("valid_string", "value");
-    attributes.putInt("valid_int", 1);
-    attributes.putLong("valid_long", 1L);
-    attributes.putFloat("valid_float", 1.1f);
-    attributes.putDouble("valid_double", 1.1);
-    attributes.putBoolean("valid_boolean", true);
-
-    try {
-      JSONObject actualJson = new JSONObject(attributes.toJsonString());
-      Truth.assertThat(actualJson.getString("valid_string")).isEqualTo("value");
-      Truth.assertThat(actualJson.getInt("valid_int")).isEqualTo(1);
-      Truth.assertThat(actualJson.getLong("valid_long")).isEqualTo(1L);
-      Truth.assertThat((float) actualJson.getDouble("valid_float")).isEqualTo(1.1f);
-      Truth.assertThat(actualJson.getDouble("valid_double")).isEqualTo(1.1);
-      Truth.assertThat(actualJson.getBoolean("valid_boolean")).isTrue();
-    } catch (Exception e) {
-      Truth.assertWithMessage("Failed to parse JSON").fail();
-    }
   }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
@@ -367,11 +367,11 @@ public class DeployGateInterfaceTest {
 
     @Test
     public void getBuildEnvironment() {
-        DeployGate.getBuildEnvironment();
+        Truth.assertThat(DeployGate.getBuildEnvironment()).isNotNull();
     }
 
     @Test
     public void getRuntimeExtra() {
-        DeployGate.getRuntimeExtra();
+        Truth.assertThat(DeployGate.getRuntimeExtra()).isNotNull();
     }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
@@ -434,4 +434,161 @@ public class DeployGateInterfaceTest {
     public void removeAllRuntimeExtraValues() {
         DeployGate.removeAllRuntimeExtraValues();
     }
+
+    @Test
+    public void putCustomValues() {
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid", "value")).isFalse();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid", "value")).isFalse();
+
+        DeployGate.install(app);
+
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid", "value")).isTrue();
+    }
+
+    @Test
+    public void putCustomValues__keyPattern() {
+        DeployGate.install(app);
+
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_underscore", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_1_number", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("min", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("ng", "value")).isFalse();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("true", "value")).isFalse();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("false", "value")).isFalse();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("null", "value")).isFalse();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid-hyphen", "value")).isFalse();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid#sharp", "value")).isFalse();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid$dollar", "value")).isFalse();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid.dot", "value")).isFalse();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid!bang", "value")).isFalse();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid*glob", "value")).isFalse();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalidUpperCase", "value")).isFalse();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("12345", "value")).isFalse();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("1_invalid_begin_number", "value")).isFalse();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_key_with_length_under_32", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid_key_with_length_over_32_characters", "value")).isFalse();
+
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_underscore", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_1_number", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("min", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("ng", "value")).isFalse();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("true", "value")).isFalse();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("false", "value")).isFalse();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("null", "value")).isFalse();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid-hyphen", "value")).isFalse();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid#sharp", "value")).isFalse();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid$dollar", "value")).isFalse();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid.dot", "value")).isFalse();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid!bang", "value")).isFalse();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid*glob", "value")).isFalse();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalidUpperCase", "value")).isFalse();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("12345", "value")).isFalse();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("1_invalid_begin_number", "value")).isFalse();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_key_with_length_under_32", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid_key_with_length_over_32_characters", "value")).isFalse();
+    }
+
+    @Test
+    public void putCustomValues__valuePattern() {
+        DeployGate.install(app);
+
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_string", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_int", 1)).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_long", 1L)).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_float", 1.1f)).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_double", 1.1)).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_boolean", true)).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid_too_long_string", "this is too long string value. we cannot accept value if size over 64.")).isFalse();
+
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_string", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_int", 1)).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_long", 1L)).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_float", 1.1f)).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_double", 1.1)).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_boolean", true)).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid_too_long_string", "this is too long string value. we cannot accept value if size over 64.")).isFalse();
+    }
+
+    @Test
+    public void setBuildEnvironment__maxSize() {
+        DeployGate.install(app);
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key1", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key2", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key3", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key4", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key5", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key6", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key7", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key8", "value")).isTrue();
+
+        // allow to overwrite
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key1", "value2")).isTrue();
+        // not allow to put value with new key because of max size
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key9", "value")).isFalse();
+
+        DeployGate.removeBuildEnvironmentValue("key8");
+
+        // allow to put value with new key after remove exists key
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key9", "value")).isTrue();
+        // allow to overwrite
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key1", "value3")).isTrue();
+        // not allow to put value with new key because of max size
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key10", "value")).isFalse();
+
+        DeployGate.removeAllBuildEnvironmentValues();
+
+        // allow to put value less than max size
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key1", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key2", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key3", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key4", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key5", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key6", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key7", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key8", "value")).isTrue();
+        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key9", "value")).isFalse();
+    }
+
+    @Test
+    public void setRuntimeExtra__maxSize() {
+        DeployGate.install(app);
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key1", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key2", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key3", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key4", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key5", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key6", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key7", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key8", "value")).isTrue();
+
+        // allow to overwrite
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key1", "value2")).isTrue();
+        // not allow to put value with new key because of max size
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key9", "value")).isFalse();
+
+        DeployGate.removeRuntimeExtraValue("key8");
+
+        // allow to put value with new key after remove exists key
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key9", "value")).isTrue();
+        // allow to overwrite
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key1", "value3")).isTrue();
+        // not allow to put value with new key because of max size
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key10", "value")).isFalse();
+
+        DeployGate.removeAllRuntimeExtraValues();
+
+        // allow to put value less than max size
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key1", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key2", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key3", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key4", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key5", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key6", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key7", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key8", "value")).isTrue();
+        Truth.assertThat(DeployGate.putRuntimeExtraValue("key9", "value")).isFalse();
+    }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
@@ -367,31 +367,11 @@ public class DeployGateInterfaceTest {
 
     @Test
     public void getBuildEnvironment() {
-        Truth.assertThat(DeployGate.getBuildEnvironment()).isNull();
-    }
-
-    @Test
-    public void setBuildEnvironment() {
-        DeployGate.setBuildEnvironment(null);
-    }
-
-    @Test
-    public void clearBuildEnvironment() {
-        DeployGate.clearBuildEnvironment();
+        DeployGate.getBuildEnvironment();
     }
 
     @Test
     public void getRuntimeExtra() {
-        Truth.assertThat(DeployGate.getRuntimeExtra()).isNull();
-    }
-
-    @Test
-    public void setRuntimeExtra() {
-        DeployGate.setRuntimeExtra(null);
-    }
-
-    @Test
-    public void clearRuntimeExtra() {
-        DeployGate.clearRuntimeExtra();
+        DeployGate.getRuntimeExtra();
     }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
@@ -364,4 +364,74 @@ public class DeployGateInterfaceTest {
     public void getDistributionUserName() {
         Truth.assertThat(DeployGate.getDistributionUserName()).isNull();
     }
+
+    @Test
+    public void putBuildEnvironmentValue__string() {
+        DeployGate.putBuildEnvironmentValue("key", "value");
+    }
+
+    @Test
+    public void putBuildEnvironmentValue__int() {
+        DeployGate.putBuildEnvironmentValue("key", 1);
+    }
+
+    @Test
+    public void putBuildEnvironmentValue__float() {
+        DeployGate.putBuildEnvironmentValue("key", 1.0f);
+    }
+
+    @Test
+    public void putBuildEnvironmentValue__double() {
+        DeployGate.putBuildEnvironmentValue("key", 1.0);
+    }
+
+    @Test
+    public void putBuildEnvironmentValue__long() {
+        DeployGate.putBuildEnvironmentValue("key", 1L);
+    }
+
+    @Test
+    public void removeBuildEnvironmentValue() {
+        DeployGate.removeBuildEnvironmentValue("key");
+    }
+
+    @Test
+    public void removeAllBuildEnvironmentValues() {
+        DeployGate.removeAllBuildEnvironmentValues();
+    }
+
+    @Test
+    public void putRuntimeExtraValue__string() {
+        DeployGate.putRuntimeExtraValue("key", "value");
+    }
+
+    @Test
+    public void putRuntimeExtrasValue__int() {
+        DeployGate.putRuntimeExtraValue("key", 1);
+    }
+
+    @Test
+    public void putRuntimeExtrasValue__float() {
+        DeployGate.putRuntimeExtraValue("key", 1.0f);
+    }
+
+    @Test
+    public void putRuntimeExtrasValue__double() {
+        DeployGate.putRuntimeExtraValue("key", 1.0);
+    }
+
+    @Test
+    public void putRuntimeExtrasValue__long() {
+        DeployGate.putRuntimeExtraValue("key", 1L);
+    }
+
+    @Test
+    public void removeRuntimeExtrasValue() {
+        DeployGate.removeRuntimeExtraValue("key");
+    }
+
+    @Test
+    public void removeAllRuntimeExtraValues() {
+        DeployGate.removeAllRuntimeExtraValues();
+    }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
@@ -366,229 +366,32 @@ public class DeployGateInterfaceTest {
     }
 
     @Test
-    public void putBuildEnvironmentValue__string() {
-        DeployGate.putBuildEnvironmentValue("key", "value");
+    public void getBuildEnvironment() {
+        Truth.assertThat(DeployGate.getBuildEnvironment()).isNull();
     }
 
     @Test
-    public void putBuildEnvironmentValue__int() {
-        DeployGate.putBuildEnvironmentValue("key", 1);
+    public void setBuildEnvironment() {
+        DeployGate.setBuildEnvironment(null);
     }
 
     @Test
-    public void putBuildEnvironmentValue__float() {
-        DeployGate.putBuildEnvironmentValue("key", 1.0f);
+    public void clearBuildEnvironment() {
+        DeployGate.clearBuildEnvironment();
     }
 
     @Test
-    public void putBuildEnvironmentValue__double() {
-        DeployGate.putBuildEnvironmentValue("key", 1.0);
+    public void getRuntimeExtra() {
+        Truth.assertThat(DeployGate.getRuntimeExtra()).isNull();
     }
 
     @Test
-    public void putBuildEnvironmentValue__long() {
-        DeployGate.putBuildEnvironmentValue("key", 1L);
+    public void setRuntimeExtra() {
+        DeployGate.setRuntimeExtra(null);
     }
 
     @Test
-    public void removeBuildEnvironmentValue() {
-        DeployGate.removeBuildEnvironmentValue("key");
-    }
-
-    @Test
-    public void removeAllBuildEnvironmentValues() {
-        DeployGate.removeAllBuildEnvironmentValues();
-    }
-
-    @Test
-    public void putRuntimeExtraValue__string() {
-        DeployGate.putRuntimeExtraValue("key", "value");
-    }
-
-    @Test
-    public void putRuntimeExtrasValue__int() {
-        DeployGate.putRuntimeExtraValue("key", 1);
-    }
-
-    @Test
-    public void putRuntimeExtrasValue__float() {
-        DeployGate.putRuntimeExtraValue("key", 1.0f);
-    }
-
-    @Test
-    public void putRuntimeExtrasValue__double() {
-        DeployGate.putRuntimeExtraValue("key", 1.0);
-    }
-
-    @Test
-    public void putRuntimeExtrasValue__long() {
-        DeployGate.putRuntimeExtraValue("key", 1L);
-    }
-
-    @Test
-    public void removeRuntimeExtrasValue() {
-        DeployGate.removeRuntimeExtraValue("key");
-    }
-
-    @Test
-    public void removeAllRuntimeExtraValues() {
-        DeployGate.removeAllRuntimeExtraValues();
-    }
-
-    @Test
-    public void putCustomValues() {
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid", "value")).isFalse();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid", "value")).isFalse();
-
-        DeployGate.install(app);
-
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid", "value")).isTrue();
-    }
-
-    @Test
-    public void putCustomValues__keyPattern() {
-        DeployGate.install(app);
-
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_underscore", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_1_number", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("min", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("ng", "value")).isFalse();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("true", "value")).isFalse();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("false", "value")).isFalse();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("null", "value")).isFalse();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid-hyphen", "value")).isFalse();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid#sharp", "value")).isFalse();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid$dollar", "value")).isFalse();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid.dot", "value")).isFalse();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid!bang", "value")).isFalse();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid*glob", "value")).isFalse();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalidUpperCase", "value")).isFalse();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("12345", "value")).isFalse();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("1_invalid_begin_number", "value")).isFalse();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_key_with_length_under_32", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid_key_with_length_over_32_characters", "value")).isFalse();
-
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_underscore", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_1_number", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("min", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("ng", "value")).isFalse();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("true", "value")).isFalse();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("false", "value")).isFalse();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("null", "value")).isFalse();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid-hyphen", "value")).isFalse();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid#sharp", "value")).isFalse();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid$dollar", "value")).isFalse();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid.dot", "value")).isFalse();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid!bang", "value")).isFalse();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid*glob", "value")).isFalse();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalidUpperCase", "value")).isFalse();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("12345", "value")).isFalse();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("1_invalid_begin_number", "value")).isFalse();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_key_with_length_under_32", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid_key_with_length_over_32_characters", "value")).isFalse();
-    }
-
-    @Test
-    public void putCustomValues__valuePattern() {
-        DeployGate.install(app);
-
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_string", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_int", 1)).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_long", 1L)).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_float", 1.1f)).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_double", 1.1)).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("valid_boolean", true)).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("invalid_too_long_string", "this is too long string value. we cannot accept value if size over 64.")).isFalse();
-
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_string", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_int", 1)).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_long", 1L)).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_float", 1.1f)).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_double", 1.1)).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("valid_boolean", true)).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("invalid_too_long_string", "this is too long string value. we cannot accept value if size over 64.")).isFalse();
-    }
-
-    @Test
-    public void setBuildEnvironment__maxSize() {
-        DeployGate.install(app);
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key1", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key2", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key3", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key4", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key5", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key6", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key7", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key8", "value")).isTrue();
-
-        // allow to overwrite
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key1", "value2")).isTrue();
-        // not allow to put value with new key because of max size
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key9", "value")).isFalse();
-
-        DeployGate.removeBuildEnvironmentValue("key8");
-
-        // allow to put value with new key after remove exists key
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key9", "value")).isTrue();
-        // allow to overwrite
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key1", "value3")).isTrue();
-        // not allow to put value with new key because of max size
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key10", "value")).isFalse();
-
-        DeployGate.removeAllBuildEnvironmentValues();
-
-        // allow to put value less than max size
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key1", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key2", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key3", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key4", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key5", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key6", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key7", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key8", "value")).isTrue();
-        Truth.assertThat(DeployGate.putBuildEnvironmentValue("key9", "value")).isFalse();
-    }
-
-    @Test
-    public void setRuntimeExtra__maxSize() {
-        DeployGate.install(app);
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key1", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key2", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key3", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key4", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key5", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key6", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key7", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key8", "value")).isTrue();
-
-        // allow to overwrite
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key1", "value2")).isTrue();
-        // not allow to put value with new key because of max size
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key9", "value")).isFalse();
-
-        DeployGate.removeRuntimeExtraValue("key8");
-
-        // allow to put value with new key after remove exists key
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key9", "value")).isTrue();
-        // allow to overwrite
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key1", "value3")).isTrue();
-        // not allow to put value with new key because of max size
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key10", "value")).isFalse();
-
-        DeployGate.removeAllRuntimeExtraValues();
-
-        // allow to put value less than max size
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key1", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key2", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key3", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key4", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key5", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key6", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key7", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key8", "value")).isTrue();
-        Truth.assertThat(DeployGate.putRuntimeExtraValue("key9", "value")).isFalse();
+    public void clearRuntimeExtra() {
+        DeployGate.clearRuntimeExtra();
     }
 }

--- a/sdk/src/test/java/com/deploygate/sdk/HostAppTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/HostAppTest.java
@@ -36,7 +36,7 @@ public class HostAppTest {
         Truth.assertThat(app.canUseLogcat).isTrue();
         Truth.assertThat(app.packageName).isEqualTo("com.deploygate.sdk.test");
         Truth.assertThat(app.sdkVersion).isEqualTo(4);
-        Truth.assertThat(app.sdkArtifactVersion).isEqualTo("4.7.1");
+        Truth.assertThat(app.sdkArtifactVersion).isEqualTo("4.8.0");
         Truth.assertThat(app.activeFeatureFlags).isEqualTo(FULL_BIT);
         Truth.assertThat(app.canUseDeviceCapture()).isTrue();
     }

--- a/sdkMock/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -2,21 +2,41 @@ package com.deploygate.sdk;
 
 public class CustomAttributes {
 
-  public CustomAttributes() {}
+  public CustomAttributes() {
+  }
 
-  public boolean put(String key, String value) {
+  public boolean putString(String key, String value) {
     return false;
   }
 
-  public boolean put(String key, Number value) {
+  public boolean putInt(String key, int value) {
     return false;
   }
 
-  public boolean put(String key, Boolean value) {
+  public boolean putLong(String key, long value) {
+    return false;
+  }
+
+  public boolean putFloat(String key, float value) {
+    return false;
+  }
+
+  public boolean putDouble(String key, double value) {
+    return false;
+  }
+
+  public boolean putBoolean(String key, boolean value) {
     return false;
   }
 
   public void remove(String key) {
+  }
+
+  public void removeAll() {
+  }
+
+  public int size() {
+    return 0;
   }
 
   public String toJsonString() {

--- a/sdkMock/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -1,0 +1,25 @@
+package com.deploygate.sdk;
+
+public class CustomAttributes {
+
+  public CustomAttributes() {}
+
+  public boolean put(String key, String value) {
+    return false;
+  }
+
+  public boolean put(String key, Number value) {
+    return false;
+  }
+
+  public boolean put(String key, Boolean value) {
+    return false;
+  }
+
+  public void remove(String key) {
+  }
+
+  public String toJsonString() {
+    return null;
+  }
+}

--- a/sdkMock/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -1,8 +1,8 @@
 package com.deploygate.sdk;
 
-public class CustomAttributes {
+public final class CustomAttributes {
 
-  public CustomAttributes() {
+  CustomAttributes() {
   }
 
   public boolean putString(String key, String value) {
@@ -39,7 +39,11 @@ public class CustomAttributes {
     return 0;
   }
 
-  public String toJsonString() {
+  public boolean isEmpty() {
+    return true;
+  }
+
+  String toJsonString() {
     return null;
   }
 }

--- a/sdkMock/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -44,6 +44,6 @@ public final class CustomAttributes {
   }
 
   String toJsonString() {
-    return null;
+    return "{}";
   }
 }

--- a/sdkMock/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -34,12 +34,4 @@ public final class CustomAttributes {
 
   public void removeAll() {
   }
-
-  public int size() {
-    return 0;
-  }
-
-  public boolean isEmpty() {
-    return true;
-  }
 }

--- a/sdkMock/src/main/java/com/deploygate/sdk/CustomAttributes.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/CustomAttributes.java
@@ -42,8 +42,4 @@ public final class CustomAttributes {
   public boolean isEmpty() {
     return true;
   }
-
-  String toJsonString() {
-    return "{}";
-  }
 }

--- a/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -180,63 +180,23 @@ public class DeployGate {
         return null;
     }
 
-    public static boolean putBuildEnvironmentValue(String key, String value) {
-        return false;
+    public static CustomAttributes getBuildEnvironment() {
+        return null;
     }
 
-    public static boolean putBuildEnvironmentValue(String key, int value) {
-        return false;
+    public static void setBuildEnvironment(CustomAttributes attrs) {
     }
 
-    public static boolean putBuildEnvironmentValue(String key, long value) {
-        return false;
+    public static void clearBuildEnvironment() {
     }
 
-    public static boolean putBuildEnvironmentValue(String key, float value) {
-        return false;
+    public static CustomAttributes getRuntimeExtra() {
+        return null;
     }
 
-    public static boolean putBuildEnvironmentValue(String key, double value) {
-        return false;
+    public static void setRuntimeExtra(CustomAttributes attrs) {
     }
 
-    public static boolean putBuildEnvironmentValue(String key, boolean value) {
-        return false;
-    }
-
-    public static void removeBuildEnvironmentValue(String key) {
-    }
-
-    public static void removeAllBuildEnvironmentValues() {
-    }
-
-    public static boolean putRuntimeExtraValue(String key, String value) {
-        return false;
-    }
-
-    public static boolean putRuntimeExtraValue(String key, int value) {
-        return false;
-    }
-
-    public static boolean putRuntimeExtraValue(String key, long value) {
-        return false;
-    }
-
-    public static boolean putRuntimeExtraValue(String key, float value) {
-        return false;
-    }
-
-    public static boolean putRuntimeExtraValue(String key, double value) {
-        return false;
-    }
-
-    public static boolean putRuntimeExtraValue(String key, boolean value) {
-        return false;
-    }
-
-    public static void removeRuntimeExtraValue(String key) {
-    }
-
-    public static void removeAllRuntimeExtraValues() {
+    public static void clearRuntimeExtra() {
     }
 }

--- a/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -5,6 +5,8 @@ import android.content.Context;
 
 public class DeployGate {
 
+    private static final CustomAttributes sAttributes = new CustomAttributes();
+
     static void clear() {
     }
 
@@ -181,10 +183,10 @@ public class DeployGate {
     }
 
     public static CustomAttributes getBuildEnvironment() {
-        return null;
+        return sAttributes;
     }
 
     public static CustomAttributes getRuntimeExtra() {
-        return null;
+        return sAttributes;
     }
 }

--- a/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -210,33 +210,33 @@ public class DeployGate {
     public static void removeAllBuildEnvironmentValues() {
     }
 
-    public static boolean putRuntimeExtrasValue(String key, String value) {
+    public static boolean putRuntimeExtraValue(String key, String value) {
         return false;
     }
 
-    public static boolean putRuntimeExtrasValue(String key, int value) {
+    public static boolean putRuntimeExtraValue(String key, int value) {
         return false;
     }
 
-    public static boolean putRuntimeExtrasValue(String key, long value) {
+    public static boolean putRuntimeExtraValue(String key, long value) {
         return false;
     }
 
-    public static boolean putRuntimeExtrasValue(String key, float value) {
+    public static boolean putRuntimeExtraValue(String key, float value) {
         return false;
     }
 
-    public static boolean putRuntimeExtrasValue(String key, double value) {
+    public static boolean putRuntimeExtraValue(String key, double value) {
         return false;
     }
 
-    public static boolean putRuntimeExtrasValue(String key, boolean value) {
+    public static boolean putRuntimeExtraValue(String key, boolean value) {
         return false;
     }
 
-    public static void removeRuntimeExtrasValue(String key) {
+    public static void removeRuntimeExtraValue(String key) {
     }
 
-    public static void removeAllRuntimeExtrasValues() {
+    public static void removeAllRuntimeExtraValues() {
     }
 }

--- a/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -184,19 +184,7 @@ public class DeployGate {
         return null;
     }
 
-    public static void setBuildEnvironment(CustomAttributes attrs) {
-    }
-
-    public static void clearBuildEnvironment() {
-    }
-
     public static CustomAttributes getRuntimeExtra() {
         return null;
-    }
-
-    public static void setRuntimeExtra(CustomAttributes attrs) {
-    }
-
-    public static void clearRuntimeExtra() {
     }
 }

--- a/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -179,4 +179,64 @@ public class DeployGate {
     public static String getDistributionUserName() {
         return null;
     }
+
+    public static boolean putBuildEnvironmentValue(String key, String value) {
+        return false;
+    }
+
+    public static boolean putBuildEnvironmentValue(String key, int value) {
+        return false;
+    }
+
+    public static boolean putBuildEnvironmentValue(String key, long value) {
+        return false;
+    }
+
+    public static boolean putBuildEnvironmentValue(String key, float value) {
+        return false;
+    }
+
+    public static boolean putBuildEnvironmentValue(String key, double value) {
+        return false;
+    }
+
+    public static boolean putBuildEnvironmentValue(String key, boolean value) {
+        return false;
+    }
+
+    public static void removeBuildEnvironmentValue(String key) {
+    }
+
+    public static void removeAllBuildEnvironmentValues() {
+    }
+
+    public static boolean putRuntimeExtrasValue(String key, String value) {
+        return false;
+    }
+
+    public static boolean putRuntimeExtrasValue(String key, int value) {
+        return false;
+    }
+
+    public static boolean putRuntimeExtrasValue(String key, long value) {
+        return false;
+    }
+
+    public static boolean putRuntimeExtrasValue(String key, float value) {
+        return false;
+    }
+
+    public static boolean putRuntimeExtrasValue(String key, double value) {
+        return false;
+    }
+
+    public static boolean putRuntimeExtrasValue(String key, boolean value) {
+        return false;
+    }
+
+    public static void removeRuntimeExtrasValue(String key) {
+    }
+
+    public static void removeAllRuntimeExtrasValues() {
+    }
 }

--- a/sdkMock/src/test/java/com/deploygate/sdk/CustomAttributesInterfaceTest.java
+++ b/sdkMock/src/test/java/com/deploygate/sdk/CustomAttributesInterfaceTest.java
@@ -1,0 +1,1 @@
+../../../../../../../sdkMock/src/test/java/com/deploygate/sdk/CustomAttributesInterfaceTest.java

--- a/sdkMock/src/test/java/com/deploygate/sdk/CustomAttributesInterfaceTest.java
+++ b/sdkMock/src/test/java/com/deploygate/sdk/CustomAttributesInterfaceTest.java
@@ -1,1 +1,1 @@
-../../../../../../../sdkMock/src/test/java/com/deploygate/sdk/CustomAttributesInterfaceTest.java
+../../../../../../../sdk/src/test/java/com/deploygate/sdk/CustomAttributesInterfaceTest.java


### PR DESCRIPTION
I added an implementation that will be used to enhance the capture function provided after the next version.

- Users can add attributes freely and their values via `CustomAttributes` class .
- Attributes are divided into two groups. `BuildEnvironment` or `RuntimeExtra`.
  - DeployGate instance keeps `CustomAttriutes` of each groups.
- The attributes are sent automatically to DeployGate by SDK when the capture is created.
  - When SDK received `ACTION_COLLECT_DEVICE_STATES` event, SDK will write values via content provider.