### PR TITLE
Fix: use sonatype user token for uploading artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
           echo >> gradle.properties
           cat<<EOF >> gradle.properties
           systemProp.org.gradle.internal.http.socketTimeout=120000
-          NEXUS_USERNAME=${{ secrets.SHARED_NEXUS_USERNAME }}
-          NEXUS_PASSWORD=${{ secrets.SHARED_NEXUS_PASSWORD }}
+          NEXUS_USERNAME=${{ secrets.SHARED_NEXUS_TOKEN_USERNAME }}
+          NEXUS_PASSWORD=${{ secrets.SHARED_NEXUS_TOKEN_PASSWORD }}
           EOF
       - name: Publish artifacts
         run: ./scripts/release.sh


### PR DESCRIPTION
According to [the notice from sonatype](https://central.sonatype.org/news/20240617_migration_of_accounts/#the-impact-on-ossrh-and-the-central-publisher-portal), we cannot use username and password when uploading artifacts to the repository.

So, we should use a user token in our GitHub Actions workflow.

Ref. https://central.sonatype.org/news/20240617_migration_of_accounts/#the-impact-on-ossrh-and-the-central-publisher-portal