### PR TITLE
Fix: set GRADLE_OPTS to avoid causing OOM when upload artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   production-release:
     runs-on: ubuntu-latest
+    env:
+      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4g -XX:MaxMetaspaceSize=2g -Dkotlin.daemon.jvm.options=-Xmx1536m"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3


### PR DESCRIPTION
Workflow of `Release artifacts` was failed with `java.lang.OutOfMemoryError: Metaspace`.
But the workflow of `Build and test projects` was successful.

`Build and test projects` has `GRADLE_OPTS` env and defined max size of Java heap memory and metaspace for the gradle deamon.

So, I think we can fix this by setting `GRADLE_OPTS` in your workflow file.