### PR TITLE
Add new callback interface to receive the Capture creation event

### DIFF
--- a/sample/src/main/java/com/deploygate/sample/App.java
+++ b/sample/src/main/java/com/deploygate/sample/App.java
@@ -66,6 +66,11 @@ public class App extends Application {
                 Log.i(TAG, message);
                 DeployGate.logInfo(message);
             })
+            .setCaptureCreateCallback((captureUrl, createdAtMillis) -> {
+                String message = String.format(Locale.US, "onCaptureCreated(%s)", captureUrl);
+                Log.i(TAG, message);
+                DeployGate.logInfo(message);
+            })
             .setEnabledOnNonDebuggableBuild(true)
             .build();
 

--- a/sample/src/main/java/com/deploygate/sample/SampleActivity.java
+++ b/sample/src/main/java/com/deploygate/sample/SampleActivity.java
@@ -251,7 +251,9 @@ public class SampleActivity extends Activity implements DeployGateInitializeCall
 
     @Override
     public void onCaptureCreated(String captureUrl, long createdAtMillis) {
-        Log.d(TAG, "Capture created: url=" + captureUrl + ", created_at=" + createdAtMillis);
-        Toast.makeText(this, "onCaptureCreated: " + captureUrl, Toast.LENGTH_LONG).show();
+        // will be called when the capture is created
+        String message = "onCaptureCreated: url=" + captureUrl + ", created_at=" + createdAtMillis;
+        Log.d(TAG, message);
+        Toast.makeText(this, "onCaptureCreated called", Toast.LENGTH_LONG).show();
     }
 }

--- a/sample/src/main/java/com/deploygate/sample/SampleActivity.java
+++ b/sample/src/main/java/com/deploygate/sample/SampleActivity.java
@@ -16,11 +16,12 @@ import android.widget.Toast;
 
 import com.deploygate.sdk.CustomAttributes;
 import com.deploygate.sdk.DeployGate;
+import com.deploygate.sdk.DeployGateCaptureCreateCallback;
 import com.deploygate.sdk.DeployGateInitializeCallback;
 import com.deploygate.sdk.DeployGateStatusChangeCallback;
 import com.deploygate.sdk.DeployGateUpdateAvailableCallback;
 
-public class SampleActivity extends Activity implements DeployGateInitializeCallback, DeployGateStatusChangeCallback, DeployGateUpdateAvailableCallback {
+public class SampleActivity extends Activity implements DeployGateInitializeCallback, DeployGateStatusChangeCallback, DeployGateUpdateAvailableCallback, DeployGateCaptureCreateCallback {
 
     private static final String TAG = "SampleActivity";
 
@@ -74,6 +75,7 @@ public class SampleActivity extends Activity implements DeployGateInitializeCall
         DeployGate.registerInitializeCallback(this);
         DeployGate.registerStatusChangeCallback(this);
         DeployGate.registerUpdateAvailableCallback(this);
+        DeployGate.registerCaptureCreateCallback(this);
 
         // finally, call refresh() method if you want to check the status immediately
         DeployGate.refresh();
@@ -87,6 +89,7 @@ public class SampleActivity extends Activity implements DeployGateInitializeCall
         DeployGate.unregisterInitializeCallback(this);
         DeployGate.unregisterStatusChangeCallback(this);
         DeployGate.unregisterUpdateAvailableCallback(this);
+        DeployGate.unregisterCaptureCreateCallback(this);
     }
 
 
@@ -244,5 +247,11 @@ public class SampleActivity extends Activity implements DeployGateInitializeCall
 
         mTitleText.setText(getString(R.string.update_available, serial, versionName, versionCode, message));
         mUpdateButton.setVisibility(View.VISIBLE);
+    }
+
+    @Override
+    public void onCaptureCreated(String captureUrl, long createdAtMillis) {
+        Log.d(TAG, "Capture created: url=" + captureUrl + ", created_at=" + createdAtMillis);
+        Toast.makeText(this, "onCaptureCreated: " + captureUrl, Toast.LENGTH_LONG).show();
     }
 }

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -167,14 +167,14 @@ public class DeployGate {
                 }
             } else if(DeployGateEvent.ACTION_CAPTURE_CREATED.equals(action)) {
                 final String captureUrl = extras.getString(DeployGateEvent.EXTRA_CAPTURE_URL);
-                final long captureCreatedAt = extras.getLong(DeployGateEvent.EXTRA_CAPTURE_CREATED_AT, DeployGateEvent.DEFAULT_EXTRA_CAPTURE_CREATE_AT);
+                final long captureCreatedAt = extras.getLong(DeployGateEvent.EXTRA_CAPTURE_CREATED_AT, -1);
 
                 if (TextUtils.isEmpty(captureUrl)) {
                     Logger.w("Capture ID is missing in the extra");
                     return;
                 }
 
-                if (captureCreatedAt == DeployGateEvent.DEFAULT_EXTRA_CAPTURE_CREATE_AT) {
+                if (captureCreatedAt < 0) {
                     Logger.w("Capture created at is missing in the extra");
                     return;
                 }

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -167,14 +167,14 @@ public class DeployGate {
                 }
             } else if(DeployGateEvent.ACTION_CAPTURE_CREATED.equals(action)) {
                 final String captureUrl = extras.getString(DeployGateEvent.EXTRA_CAPTURE_URL);
-                final long captureCreatedAt = extras.getLong(DeployGateEvent.EXTRA_CAPTURE_CREATED_AT, -1);
+                final long captureCreatedAt = extras.getLong(DeployGateEvent.EXTRA_CAPTURE_CREATED_AT, DeployGateEvent.DEFAULT_EXTRA_CAPTURE_CREATE_AT);
 
                 if (TextUtils.isEmpty(captureUrl)) {
                     Logger.w("Capture ID is missing in the extra");
                     return;
                 }
 
-                if (captureCreatedAt < 0) {
+                if (captureCreatedAt == DeployGateEvent.DEFAULT_EXTRA_CAPTURE_CREATE_AT) {
                     Logger.w("Capture created at is missing in the extra");
                     return;
                 }

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -303,7 +303,6 @@ public class DeployGate {
                 for (DeployGateStatusChangeCallback callback : mStatusChangeCallbacks) {
                     callback.onStatusChanged(false, false, null, false);
                 }
-
             }
         });
     }
@@ -1722,5 +1721,12 @@ public class DeployGate {
      */
     static HashSet<DeployGateUpdateAvailableCallback> getUpdateAvailableCallbacks() {
         return sInstance != null ? sInstance.mUpdateAvailableCallbacks : null;
+    }
+
+    /**
+     * Not a public API. This is only for testing.
+     */
+    static HashSet<DeployGateCaptureCreateCallback> getCaptureCreateCallbacks() {
+        return sInstance != null ? sInstance.mCaptureCreateCallbacks : null;
     }
 }

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -165,6 +165,28 @@ public class DeployGate {
                 } catch (Throwable t) {
                     Logger.w(t, "failed to report device states");
                 }
+            } else if(DeployGateEvent.ACTION_CAPTURE_CREATED.equals(action)) {
+                final String captureUrl = extras.getString(DeployGateEvent.EXTRA_CAPTURE_URL);
+                final long captureCreatedAt = extras.getLong(DeployGateEvent.EXTRA_CAPTURE_CREATED_AT, -1);
+
+                if (TextUtils.isEmpty(captureUrl)) {
+                    Logger.w("Capture ID is missing in the extra");
+                    return;
+                }
+
+                if (captureCreatedAt < 0) {
+                    Logger.w("Capture created at is missing in the extra");
+                    return;
+                }
+
+                mHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        for (DeployGateCaptureCreateCallback callback : mCaptureCreateCallbacks) {
+                            callback.onCaptureCreated(captureUrl, captureCreatedAt);
+                        }
+                    }
+                });
             } else {
                 Logger.w("%s is not supported by this sdk version", action);
             }

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -68,6 +68,7 @@ public class DeployGate {
     private final HashSet<DeployGateInitializeCallback> mInitializeCallbacks;
     private final HashSet<DeployGateStatusChangeCallback> mStatusChangeCallbacks;
     private final HashSet<DeployGateUpdateAvailableCallback> mUpdateAvailableCallbacks;
+    private final HashSet<DeployGateCaptureCreateCallback> mCaptureCreateCallbacks;
     private final HashMap<String, Bundle> mPendingEvents;
     private final String mExpectedAuthor;
     private String mAuthor;
@@ -328,6 +329,7 @@ public class DeployGate {
         mInitializeCallbacks = new HashSet<>();
         mStatusChangeCallbacks = new HashSet<>();
         mUpdateAvailableCallbacks = new HashSet<>();
+        mCaptureCreateCallbacks = new HashSet<>();
         mPendingEvents = new HashMap<>();
         mExpectedAuthor = sdkConfiguration.appOwnerName;
 
@@ -343,6 +345,10 @@ public class DeployGate {
 
         if (sdkConfiguration.updateAvailableCallback != null) {
             mUpdateAvailableCallbacks.add(sdkConfiguration.updateAvailableCallback);
+        }
+
+        if (sdkConfiguration.captureCreateCallback != null) {
+            mCaptureCreateCallbacks.add(sdkConfiguration.captureCreateCallback);
         }
 
         mInitializedLatch = new CountDownLatch(1);
@@ -939,6 +945,52 @@ public class DeployGate {
 
     private void unregisterUpdateAvailableCallbackInternal(DeployGateUpdateAvailableCallback callback) {
         mUpdateAvailableCallbacks.remove(callback);
+    }
+
+    /**
+     * Register a callback listener about the new capture is created.
+     * Don't forget to unregister the callback listener when it is no longer needed (e.g., on destroying an activity.)
+     * If the listener has already in the callback list, just ignored.
+     *
+     * @param callback callback listener
+     * @see #unregisterCaptureCreateCallback(DeployGateCaptureCreateCallback)
+     * @since 4.9.0
+     */
+    public static void registerCaptureCreateCallback(DeployGateCaptureCreateCallback callback) {
+        if (sInstance == null) {
+            return;
+        }
+        if (callback == null) {
+            return;
+        }
+
+        sInstance.registerCaptureCaptureCallbackInternal(callback);
+    }
+
+    private void registerCaptureCaptureCallbackInternal(DeployGateCaptureCreateCallback callback) {
+        mCaptureCreateCallbacks.add(callback);
+    }
+
+    /**
+     * Unregister a callback listener.
+     * If the listener was not registered, just ignored.
+     *
+     * @param callback callback listener to be removed
+     * @since 4.9.0
+     */
+    public static void unregisterCaptureCreateCallback(DeployGateCaptureCreateCallback callback) {
+        if (sInstance == null) {
+            return;
+        }
+        if (callback == null) {
+            return;
+        }
+
+        sInstance.unregisterCaptureCaptureCallbackInternal(callback);
+    }
+
+    private void unregisterCaptureCaptureCallbackInternal(DeployGateCaptureCreateCallback callback) {
+        mCaptureCreateCallbacks.remove(callback);
     }
 
     /**

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGateCaptureCreateCallback.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGateCaptureCreateCallback.java
@@ -2,9 +2,9 @@ package com.deploygate.sdk;
 
 /**
  * A callback interface to receive the capture creation event.
- * 
+ *
  * @since 4.9.0
- * @see DeployGate#registerCaptureCreateCallback(DeployGateCaptureCreateCallback) 
+ * @see DeployGate#registerCaptureCreateCallback(DeployGateCaptureCreateCallback)
  */
 public interface DeployGateCaptureCreateCallback {
     /**

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGateCaptureCreateCallback.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGateCaptureCreateCallback.java
@@ -1,0 +1,21 @@
+package com.deploygate.sdk;
+
+/**
+ * A callback interface to receive the capture creation event.
+ * 
+ * @since 4.9.0
+ * @see DeployGate#registerCaptureCreateCallback(DeployGateCaptureCreateCallback) 
+ */
+public interface DeployGateCaptureCreateCallback {
+    /**
+     * Callback to tell the new capture is successfully created.
+     *
+     * @param captureUrl      URL of the created capture
+     * @param createdAtMillis Created time of the capture in milliseconds
+     * @since 4.9.0
+     */
+    public void onCaptureCreated(
+            String captureUrl,
+            long createdAtMillis
+    );
+}

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGateSdkConfiguration.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGateSdkConfiguration.java
@@ -15,6 +15,7 @@ public final class DeployGateSdkConfiguration {
     final DeployGateInitializeCallback initializeCallback;
     final DeployGateStatusChangeCallback statusChangeCallback;
     final DeployGateUpdateAvailableCallback updateAvailableCallback;
+    final DeployGateCaptureCreateCallback captureCreateCallback;
 
     final boolean isCaptureEnabled;
 
@@ -30,7 +31,8 @@ public final class DeployGateSdkConfiguration {
                 builder.isCaptureEnabled,
                 builder.initializeCallback,
                 builder.statusChangeCallback,
-                builder.updateAvailableCallback
+                builder.updateAvailableCallback,
+                builder.captureCreateCallback
         );
     }
 
@@ -43,7 +45,8 @@ public final class DeployGateSdkConfiguration {
             boolean isCaptureEnabled,
             DeployGateInitializeCallback initializeCallback,
             DeployGateStatusChangeCallback statusChangeCallback,
-            DeployGateUpdateAvailableCallback updateAvailableCallback
+            DeployGateUpdateAvailableCallback updateAvailableCallback,
+            DeployGateCaptureCreateCallback captureCallback
     ) {
         this.customLogConfiguration = customLogConfiguration;
         this.isDisabled = isDisabled;
@@ -54,6 +57,7 @@ public final class DeployGateSdkConfiguration {
         this.initializeCallback = initializeCallback;
         this.statusChangeCallback = statusChangeCallback;
         this.updateAvailableCallback = updateAvailableCallback;
+        this.captureCreateCallback = captureCallback;
     }
 
     public static final class Builder {
@@ -71,6 +75,7 @@ public final class DeployGateSdkConfiguration {
         private DeployGateInitializeCallback initializeCallback = null;
         private DeployGateStatusChangeCallback statusChangeCallback = null;
         private DeployGateUpdateAvailableCallback updateAvailableCallback = null;
+        private DeployGateCaptureCreateCallback captureCreateCallback = null;
 
         public Builder() {
         }
@@ -181,6 +186,16 @@ public final class DeployGateSdkConfiguration {
 
         public Builder setUpdateAvailableCallback(DeployGateUpdateAvailableCallback updateAvailableCallback) {
             this.updateAvailableCallback = updateAvailableCallback;
+            return this;
+        }
+
+        /**
+         *
+         * @param captureCallback Set an instance of callback for the capture creation event.
+         * @return self
+         */
+        public Builder setCaptureCreateCallback(DeployGateCaptureCreateCallback captureCallback) {
+            this.captureCreateCallback = captureCallback;
             return this;
         }
 

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -33,6 +33,11 @@ public interface DeployGateEvent {
      */
     public static final String ACTION_COLLECT_DEVICE_STATES = "a.collect-device-states";
 
+    /**
+     * @since 4.9.0
+     */
+    public static final String ACTION_CAPTURE_CREATED = "a.capture-created";
+
     public static final String EXTRA_AUTHOR = "author";
     public static final String EXTRA_EXPECTED_AUTHOR = "expectedAuthor";
 
@@ -115,6 +120,16 @@ public interface DeployGateEvent {
      * the id of the capture.
      */
     public static final String EXTRA_CAPTURE_ID = "e.capture-id";
+
+    /**
+     * the url of the capture.
+     */
+    public static final String EXTRA_CAPTURE_URL = "e.capture-url";
+
+    /**
+     * the created time of the capture.
+     */
+    public static final String EXTRA_CAPTURE_CREATED_AT = "e.capture-created-at";
 
     /**
      * A event type for the app goes to foreground/background.

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -171,4 +171,9 @@ public interface DeployGateEvent {
         int BACKGROUND = 0;
         int FOREGROUND = 1;
     }
+
+    /**
+     * Not a public value. This is only for internal.
+     */
+    static final Long DEFAULT_EXTRA_CAPTURE_CREATE_AT = -1L;
 }

--- a/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
+++ b/sdk/src/main/java/com/deploygate/service/DeployGateEvent.java
@@ -171,9 +171,4 @@ public interface DeployGateEvent {
         int BACKGROUND = 0;
         int FOREGROUND = 1;
     }
-
-    /**
-     * Not a public value. This is only for internal.
-     */
-    static final Long DEFAULT_EXTRA_CAPTURE_CREATE_AT = -1L;
 }

--- a/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/DeployGateInterfaceTest.java
@@ -29,6 +29,7 @@ public class DeployGateInterfaceTest {
     DeployGateInitializeCallback initializeCallback;
     DeployGateStatusChangeCallback statusChangeCallback;
     DeployGateUpdateAvailableCallback updateAvailableCallback;
+    DeployGateCaptureCreateCallback captureCreateCallback;
 
     @Before
     public void setUp() {
@@ -74,6 +75,12 @@ public class DeployGateInterfaceTest {
         updateAvailableCallback = new DeployGateUpdateAvailableCallback() {
             @Override
             public void onUpdateAvailable(int revision, String versionName, int versionCode) {
+                // no-op
+            }
+        };
+        captureCreateCallback = new DeployGateCaptureCreateCallback() {
+            @Override
+            public void onCaptureCreated(String captureUrl, long createdAtMillis) {
                 // no-op
             }
         };
@@ -240,6 +247,15 @@ public class DeployGateInterfaceTest {
                 // no-op
             }
         });
+
+        DeployGate.registerCaptureCreateCallback(null);
+        DeployGate.registerCaptureCreateCallback(captureCreateCallback);
+        DeployGate.registerCaptureCreateCallback(new DeployGateCaptureCreateCallback() {
+            @Override
+            public void onCaptureCreated(String captureUrl, long createdAtMillis) {
+                // no-op
+            }
+        });
     }
 
     @Test
@@ -298,6 +314,15 @@ public class DeployGateInterfaceTest {
             }
         });
         DeployGate.unregisterUpdateAvailableCallback(updateAvailableCallback);
+
+        DeployGate.unregisterCaptureCreateCallback(null);
+        DeployGate.unregisterCaptureCreateCallback(new DeployGateCaptureCreateCallback() {
+            @Override
+            public void onCaptureCreated(String captureUrl, long createdAtMillis) {
+                // no-op
+            }
+        });
+        DeployGate.unregisterCaptureCreateCallback(captureCreateCallback);
     }
 
     @Test

--- a/sdk/src/test/java/com/deploygate/sdk/DeployGateSdkConfigurationInterfaceTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/DeployGateSdkConfigurationInterfaceTest.java
@@ -24,6 +24,7 @@ public class DeployGateSdkConfigurationInterfaceTest {
     DeployGateInitializeCallback initializeCallback;
     DeployGateStatusChangeCallback statusChangeCallback;
     DeployGateUpdateAvailableCallback updateAvailableCallback;
+    DeployGateCaptureCreateCallback captureCreateCallback;
 
     @Before
     public void setUp() {
@@ -43,6 +44,30 @@ public class DeployGateSdkConfigurationInterfaceTest {
 
             @Override
             public void onUpdateAvailable(int revision, String versionName, int versionCode) {
+                // no-op
+            }
+        };
+        initializeCallback = new DeployGateInitializeCallback() {
+            @Override
+            public void onInitialized(boolean isServiceAvailable) {
+                // no-op
+            }
+        };
+        statusChangeCallback = new DeployGateStatusChangeCallback() {
+            @Override
+            public void onStatusChanged(boolean isManaged, boolean isAuthorized, String loginUsername, boolean isStopped) {
+                // no-op
+            }
+        };
+        updateAvailableCallback = new DeployGateUpdateAvailableCallback() {
+            @Override
+            public void onUpdateAvailable(int revision, String versionName, int versionCode) {
+                // no-op
+            }
+        };
+        captureCreateCallback = new DeployGateCaptureCreateCallback() {
+            @Override
+            public void onCaptureCreated(String captureUrl, long createdAtMillis) {
                 // no-op
             }
         };
@@ -122,6 +147,16 @@ public class DeployGateSdkConfigurationInterfaceTest {
         builder.setUpdateAvailableCallback(new DeployGateUpdateAvailableCallback() {
             @Override
             public void onUpdateAvailable(int revision, String versionName, int versionCode) {
+                // no-op
+            }
+        });
+
+        // setCaptureCreateCallback
+        builder.setCaptureCreateCallback(null);
+        builder.setCaptureCreateCallback(captureCreateCallback);
+        builder.setCaptureCreateCallback(new DeployGateCaptureCreateCallback() {
+            @Override
+            public void onCaptureCreated(String captureUrl, long createdAtMillis) {
                 // no-op
             }
         });

--- a/sdk/src/test/java/com/deploygate/sdk/DeployGateSdkConfigurationTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/DeployGateSdkConfigurationTest.java
@@ -15,6 +15,7 @@ public class DeployGateSdkConfigurationTest {
     DeployGateInitializeCallback initializeCallback;
     DeployGateStatusChangeCallback statusChangeCallback;
     DeployGateUpdateAvailableCallback updateAvailableCallback;
+    DeployGateCaptureCreateCallback captureCreateCallback;
     DeployGateCallback deployGateCallback;
 
     @Before
@@ -38,6 +39,12 @@ public class DeployGateSdkConfigurationTest {
                 // no-op
             }
         };
+        captureCreateCallback = new DeployGateCaptureCreateCallback() {
+            @Override
+            public void onCaptureCreated(String captureUrl, long createdAtMillis) {
+
+            }
+        };
         deployGateCallback = new DeployGateCallback() {
             @Override
             public void onInitialized(boolean isServiceAvailable) {
@@ -59,7 +66,6 @@ public class DeployGateSdkConfigurationTest {
 
     @Test
     public void builder() {
-
         DeployGateSdkConfiguration configuration = new DeployGateSdkConfiguration.Builder()
                 .setAppOwnerName("owner")
                 .setCaptureEnabled(true)
@@ -70,6 +76,7 @@ public class DeployGateSdkConfigurationTest {
                 .setInitializeCallback(initializeCallback)
                 .setStatusChangeCallback(statusChangeCallback)
                 .setUpdateAvailableCallback(updateAvailableCallback)
+                .setCaptureCreateCallback(captureCreateCallback)
                 .build();
 
         Truth.assertThat(configuration.appOwnerName).isEqualTo("owner");
@@ -81,6 +88,7 @@ public class DeployGateSdkConfigurationTest {
         Truth.assertThat(configuration.initializeCallback).isEqualTo(initializeCallback);
         Truth.assertThat(configuration.statusChangeCallback).isEqualTo(statusChangeCallback);
         Truth.assertThat(configuration.updateAvailableCallback).isEqualTo(updateAvailableCallback);
+        Truth.assertThat(configuration.captureCreateCallback).isEqualTo(captureCreateCallback);
     }
 
     @Test
@@ -100,11 +108,13 @@ public class DeployGateSdkConfigurationTest {
                 .setInitializeCallback(initializeCallback)
                 .setStatusChangeCallback(statusChangeCallback)
                 .setUpdateAvailableCallback(updateAvailableCallback)
+                .setCaptureCreateCallback(captureCreateCallback)
                 .build();
 
         Truth.assertThat(configurationWithFineGrainedCallbacks.initializeCallback).isEqualTo(initializeCallback);
         Truth.assertThat(configurationWithFineGrainedCallbacks.statusChangeCallback).isEqualTo(statusChangeCallback);
         Truth.assertThat(configurationWithFineGrainedCallbacks.updateAvailableCallback).isEqualTo(updateAvailableCallback);
+        Truth.assertThat(configurationWithFineGrainedCallbacks.captureCreateCallback).isEqualTo(captureCreateCallback);
     }
 
     @Test

--- a/sdk/src/test/java/com/deploygate/sdk/DeployGateSdkConfigurationTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/DeployGateSdkConfigurationTest.java
@@ -42,7 +42,7 @@ public class DeployGateSdkConfigurationTest {
         captureCreateCallback = new DeployGateCaptureCreateCallback() {
             @Override
             public void onCaptureCreated(String captureUrl, long createdAtMillis) {
-
+                // no-op
             }
         };
         deployGateCallback = new DeployGateCallback() {

--- a/sdk/src/test/java/com/deploygate/sdk/DeployGateTest.java
+++ b/sdk/src/test/java/com/deploygate/sdk/DeployGateTest.java
@@ -27,6 +27,7 @@ public class DeployGateTest {
     DeployGateInitializeCallback initializeCallback;
     DeployGateStatusChangeCallback statusChangeCallback;
     DeployGateUpdateAvailableCallback updateAvailableCallback;
+    DeployGateCaptureCreateCallback captureCreateCallback;
 
     @Before
     public void setUp() {
@@ -66,6 +67,12 @@ public class DeployGateTest {
                 // no-op
             }
         };
+        captureCreateCallback = new DeployGateCaptureCreateCallback() {
+            @Override
+            public void onCaptureCreated(String captureUrl, long createdAtMillis) {
+                // no-op
+            }
+        };
 
         DeployGate.install(app, configuration);
     }
@@ -95,14 +102,22 @@ public class DeployGateTest {
                 // no-op
             }
         };
+        DeployGateCaptureCreateCallback anotherCaptureCreateCallback = new DeployGateCaptureCreateCallback() {
+            @Override
+            public void onCaptureCreated(String captureUrl, long createdAtMillis) {
+                // no-op
+            }
+        };
 
         Truth.assertThat(DeployGate.getInitializeCallbacks().size()).isEqualTo(0);
         Truth.assertThat(DeployGate.getStatusChangeCallbacks().size()).isEqualTo(0);
         Truth.assertThat(DeployGate.getUpdateAvailableCallbacks().size()).isEqualTo(0);
+        Truth.assertThat(DeployGate.getCaptureCreateCallbacks().size()).isEqualTo(0);
 
         DeployGate.registerInitializeCallback(initializeCallback);
         DeployGate.registerStatusChangeCallback(statusChangeCallback);
         DeployGate.registerUpdateAvailableCallback(updateAvailableCallback);
+        DeployGate.registerCaptureCreateCallback(captureCreateCallback);
 
         Truth.assertThat(DeployGate.getInitializeCallbacks().size()).isEqualTo(1);
         Truth.assertThat(DeployGate.getInitializeCallbacks().contains(initializeCallback)).isTrue();
@@ -113,41 +128,52 @@ public class DeployGateTest {
         Truth.assertThat(DeployGate.getUpdateAvailableCallbacks().size()).isEqualTo(1);
         Truth.assertThat(DeployGate.getUpdateAvailableCallbacks().contains(updateAvailableCallback)).isTrue();
         Truth.assertThat(DeployGate.getUpdateAvailableCallbacks().contains(anotherUpdateAvailableCallback)).isFalse();
+        Truth.assertThat(DeployGate.getCaptureCreateCallbacks().size()).isEqualTo(1);
+        Truth.assertThat(DeployGate.getCaptureCreateCallbacks().contains(captureCreateCallback)).isTrue();
+        Truth.assertThat(DeployGate.getCaptureCreateCallbacks().contains(anotherCaptureCreateCallback)).isFalse();
 
         // Each callback already registered before, so DeployGate maybe ignore this operation.
         DeployGate.registerInitializeCallback(initializeCallback);
         DeployGate.registerStatusChangeCallback(statusChangeCallback);
         DeployGate.registerUpdateAvailableCallback(updateAvailableCallback);
+        DeployGate.registerCaptureCreateCallback(captureCreateCallback);
 
         Truth.assertThat(DeployGate.getInitializeCallbacks().size()).isEqualTo(1);
         Truth.assertThat(DeployGate.getStatusChangeCallbacks().size()).isEqualTo(1);
         Truth.assertThat(DeployGate.getUpdateAvailableCallbacks().size()).isEqualTo(1);
+        Truth.assertThat(DeployGate.getCaptureCreateCallbacks().size()).isEqualTo(1);
 
         // register another callbacks
         DeployGate.registerInitializeCallback(anotherInitializeCallback);
         DeployGate.registerStatusChangeCallback(anotherStatusChangeCallback);
         DeployGate.registerUpdateAvailableCallback(anotherUpdateAvailableCallback);
+        DeployGate.registerCaptureCreateCallback(anotherCaptureCreateCallback);
 
         Truth.assertThat(DeployGate.getInitializeCallbacks().size()).isEqualTo(2);
         Truth.assertThat(DeployGate.getStatusChangeCallbacks().size()).isEqualTo(2);
         Truth.assertThat(DeployGate.getUpdateAvailableCallbacks().size()).isEqualTo(2);
+        Truth.assertThat(DeployGate.getCaptureCreateCallbacks().size()).isEqualTo(2);
 
         DeployGate.unregisterInitializeCallback(initializeCallback);
         DeployGate.unregisterStatusChangeCallback(statusChangeCallback);
         DeployGate.unregisterUpdateAvailableCallback(updateAvailableCallback);
+        DeployGate.unregisterCaptureCreateCallback(captureCreateCallback);
 
         Truth.assertThat(DeployGate.getInitializeCallbacks().size()).isEqualTo(1);
         Truth.assertThat(DeployGate.getStatusChangeCallbacks().size()).isEqualTo(1);
         Truth.assertThat(DeployGate.getUpdateAvailableCallbacks().size()).isEqualTo(1);
+        Truth.assertThat(DeployGate.getCaptureCreateCallbacks().size()).isEqualTo(1);
 
         // Each callback already unregistered before, so DeployGate maybe ignore this operation.
         DeployGate.unregisterInitializeCallback(initializeCallback);
         DeployGate.unregisterStatusChangeCallback(statusChangeCallback);
         DeployGate.unregisterUpdateAvailableCallback(updateAvailableCallback);
+        DeployGate.unregisterCaptureCreateCallback(captureCreateCallback);
 
         Truth.assertThat(DeployGate.getInitializeCallbacks().size()).isEqualTo(1);
         Truth.assertThat(DeployGate.getStatusChangeCallbacks().size()).isEqualTo(1);
         Truth.assertThat(DeployGate.getUpdateAvailableCallbacks().size()).isEqualTo(1);
+        Truth.assertThat(DeployGate.getCaptureCreateCallbacks().size()).isEqualTo(1);
     }
 
     @Test

--- a/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -89,6 +89,12 @@ public class DeployGate {
     public static void unregisterUpdateAvailableCallback(DeployGateUpdateAvailableCallback callback) {
     }
 
+    public static void registerCaptureCreateCallback(DeployGateCaptureCreateCallback callback) {
+    }
+
+    public static void unregisterCaptureCreateCallback(DeployGateCaptureCreateCallback callback) {
+    }
+
     @Deprecated
     public static void registerCallback(
             DeployGateCallback listener,

--- a/sdkMock/src/main/java/com/deploygate/sdk/DeployGateCaptureCreateCallback.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/DeployGateCaptureCreateCallback.java
@@ -2,9 +2,9 @@ package com.deploygate.sdk;
 
 /**
  * A callback interface to receive the capture creation event.
- * 
+ *
  * @since 4.9.0
- * @see DeployGate#registerCaptureCreateCallback(DeployGateCaptureCreateCallback) 
+ * @see DeployGate#registerCaptureCreateCallback(DeployGateCaptureCreateCallback)
  */
 public interface DeployGateCaptureCreateCallback {
     /**

--- a/sdkMock/src/main/java/com/deploygate/sdk/DeployGateCaptureCreateCallback.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/DeployGateCaptureCreateCallback.java
@@ -1,0 +1,21 @@
+package com.deploygate.sdk;
+
+/**
+ * A callback interface to receive the capture creation event.
+ * 
+ * @since 4.9.0
+ * @see DeployGate#registerCaptureCreateCallback(DeployGateCaptureCreateCallback) 
+ */
+public interface DeployGateCaptureCreateCallback {
+    /**
+     * Callback to tell the new capture is successfully created.
+     *
+     * @param captureUrl      URL of the created capture
+     * @param createdAtMillis Created time of the capture in milliseconds
+     * @since 4.9.0
+     */
+    public void onCaptureCreated(
+            String captureUrl,
+            long createdAtMillis
+    );
+}

--- a/sdkMock/src/main/java/com/deploygate/sdk/DeployGateSdkConfiguration.java
+++ b/sdkMock/src/main/java/com/deploygate/sdk/DeployGateSdkConfiguration.java
@@ -49,6 +49,10 @@ public final class DeployGateSdkConfiguration {
             return this;
         }
 
+        public Builder setCaptureCreateCallback(DeployGateCaptureCreateCallback captureCreateCallback) {
+            return this;
+        }
+
         public DeployGateSdkConfiguration build() {
             return new DeployGateSdkConfiguration();
         }


### PR DESCRIPTION
We provide the callback interface to notify of finished create the Capture.
You can trigger any process when the Capture is successfully created.
e.g. logging application states, saving snapshot data, etc...