### PR TITLE
feat: collecting device states on SDK

### DIFF
--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -273,6 +273,8 @@ public class DeployGate {
                 long elapsedRealtime,
                 TimeUnit timeUnit
         ) {
+            getSdkDeviceStatesCollector().collectLocale();
+
             Bundle extras = new Bundle();
             extras.putLong(DeployGateEvent.EXTRA_VISIBILITY_EVENT_ELAPSED_REAL_TIME_IN_NANOS, timeUnit.toNanos(elapsedRealtime));
             extras.putInt(DeployGateEvent.EXTRA_VISIBILITY_EVENT_TYPE, DeployGateEvent.VisibilityType.FOREGROUND);
@@ -375,8 +377,6 @@ public class DeployGate {
         mInitializedLatch = new CountDownLatch(1);
         ((Application) applicationContext).registerActivityLifecycleCallbacks(new VisibilityLifecycleCallbacks(mOnVisibilityChangeListener));
         initService(true);
-
-        getSdkDeviceStatesCollector().collectLocale();
     }
 
     private boolean initService(boolean isBoot) {

--- a/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
+++ b/sdk/src/main/java/com/deploygate/sdk/DeployGate.java
@@ -55,7 +55,7 @@ public class DeployGate {
     private static final Object sLock = new Object();
     private static CustomAttributes sBuildEnvironment;
     private static CustomAttributes sRuntimeExtra;
-    private static CustomAttributes sSdkDeviceStates;
+    private static SdkDeviceStatesCollector sSdkDeviceStatesCollector;
 
     private static DeployGate sInstance;
 
@@ -152,7 +152,7 @@ public class DeployGate {
                     cv.put(DeployGateEvent.ATTRIBUTE_KEY_RUNTIME_EXTRAS, runtimeExtraJSON);
                 }
 
-                String sdkDeviceStatusJSON = getSdkDeviceStates().getJSONString();
+                String sdkDeviceStatusJSON = getSdkDeviceStatesCollector().getJSONString();
                 if (!sdkDeviceStatusJSON.equals("{}")) {
                     cv.put(DeployGateEvent.ATTRIBUTE_KEY_SDK_DEVICE_STATES, sdkDeviceStatusJSON);
                 }
@@ -375,6 +375,8 @@ public class DeployGate {
         mInitializedLatch = new CountDownLatch(1);
         ((Application) applicationContext).registerActivityLifecycleCallbacks(new VisibilityLifecycleCallbacks(mOnVisibilityChangeListener));
         initService(true);
+
+        getSdkDeviceStatesCollector().collectLocale();
     }
 
     private boolean initService(boolean isBoot) {
@@ -1709,19 +1711,19 @@ public class DeployGate {
         return sRuntimeExtra;
     }
 
-    private static CustomAttributes getSdkDeviceStates() {
-        if (sSdkDeviceStates != null) {
-            return sSdkDeviceStates;
+    private static SdkDeviceStatesCollector getSdkDeviceStatesCollector() {
+        if (sSdkDeviceStatesCollector != null) {
+            return sSdkDeviceStatesCollector;
         }
 
         synchronized (sLock) {
-            if (sSdkDeviceStates != null) {
-                return sSdkDeviceStates;
+            if (sSdkDeviceStatesCollector != null) {
+                return sSdkDeviceStatesCollector;
             }
-            sSdkDeviceStates = new CustomAttributes();
+            sSdkDeviceStatesCollector = new SdkDeviceStatesCollector();
         }
 
-        return sSdkDeviceStates;
+        return sSdkDeviceStatesCollector;
     }
 
     /**

--- a/sdk/src/main/java/com/deploygate/sdk/SdkDeviceStatesCollector.java
+++ b/sdk/src/main/java/com/deploygate/sdk/SdkDeviceStatesCollector.java
@@ -1,0 +1,60 @@
+package com.deploygate.sdk;
+
+import android.os.Build;
+import android.util.Pair;
+
+import com.deploygate.sdk.internal.Logger;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+final class SdkDeviceStatesCollector {
+
+    private final JSONObject states = new JSONObject();
+
+    public String getJSONString() {
+        return states.toString();
+    }
+
+    public void collectLocale() {
+        Locale defaultLocale = Locale.getDefault();
+        ArrayList<Pair<String, Object>> data = new ArrayList<>();
+        data.add(new Pair<String, Object>("toString", defaultLocale.toString()));
+        data.add(new Pair<String, Object>("getLanguage", defaultLocale.getLanguage()));
+        data.add(new Pair<String, Object>("getCountry", defaultLocale.getCountry()));
+        data.add(new Pair<String, Object>("getVariant", defaultLocale.getVariant()));
+        data.add(new Pair<String, Object>("getDisplayCountry", defaultLocale.getDisplayCountry()));
+        data.add(new Pair<String, Object>("getDisplayLanguage", defaultLocale.getDisplayLanguage()));
+        data.add(new Pair<String, Object>("getDisplayName", defaultLocale.getDisplayName()));
+        data.add(new Pair<String, Object>("getDisplayVariant", defaultLocale.getDisplayVariant()));
+        data.add(new Pair<String, Object>("getISO3Country", defaultLocale.getISO3Country()));
+        data.add(new Pair<String, Object>("getISO3Language", defaultLocale.getISO3Language()));
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            data.add(new Pair<String, Object>("getDisplayScript", defaultLocale.getDisplayScript()));
+            data.add(new Pair<String, Object>("toLanguageTag", defaultLocale.toLanguageTag()));
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            data.add(new Pair<String, Object>("getScript", defaultLocale.getScript()));
+        }
+
+        putAll(Locale.class.getName(), data);
+    }
+
+    private void putAll(String fqcn, List<Pair<String, Object>> data) {
+        for (Pair<String, Object> pair : data) {
+            String key = String.format("%s$%s", fqcn, pair.first);
+            try {
+                states.put(key, pair.second);
+            } catch (JSONException e) {
+                Logger.w(e, "Failed to put info: key=%s, value=%s", key, pair.second);
+            }
+        }
+
+    }
+}

--- a/sdk/src/main/java/com/deploygate/sdk/SdkDeviceStatesCollector.java
+++ b/sdk/src/main/java/com/deploygate/sdk/SdkDeviceStatesCollector.java
@@ -1,15 +1,12 @@
 package com.deploygate.sdk;
 
 import android.os.Build;
-import android.util.Pair;
 
 import com.deploygate.sdk.internal.Logger;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Locale;
 
 final class SdkDeviceStatesCollector {
@@ -22,39 +19,34 @@ final class SdkDeviceStatesCollector {
 
     public void collectLocale() {
         Locale defaultLocale = Locale.getDefault();
-        ArrayList<Pair<String, Object>> data = new ArrayList<>();
-        data.add(new Pair<String, Object>("toString", defaultLocale.toString()));
-        data.add(new Pair<String, Object>("getLanguage", defaultLocale.getLanguage()));
-        data.add(new Pair<String, Object>("getCountry", defaultLocale.getCountry()));
-        data.add(new Pair<String, Object>("getVariant", defaultLocale.getVariant()));
-        data.add(new Pair<String, Object>("getDisplayCountry", defaultLocale.getDisplayCountry()));
-        data.add(new Pair<String, Object>("getDisplayLanguage", defaultLocale.getDisplayLanguage()));
-        data.add(new Pair<String, Object>("getDisplayName", defaultLocale.getDisplayName()));
-        data.add(new Pair<String, Object>("getDisplayVariant", defaultLocale.getDisplayVariant()));
-        data.add(new Pair<String, Object>("getISO3Country", defaultLocale.getISO3Country()));
-        data.add(new Pair<String, Object>("getISO3Language", defaultLocale.getISO3Language()));
+        String localeClassName = Locale.class.getName();
+        putState(localeClassName, "toString", defaultLocale.toString());
+        putState(localeClassName, "getLanguage", defaultLocale.getLanguage());
+        putState(localeClassName, "getCountry", defaultLocale.getCountry());
+        putState(localeClassName, "getVariant", defaultLocale.getVariant());
+        putState(localeClassName, "getDisplayCountry", defaultLocale.getDisplayCountry());
+        putState(localeClassName, "getDisplayLanguage", defaultLocale.getDisplayLanguage());
+        putState(localeClassName, "getDisplayName", defaultLocale.getDisplayName());
+        putState(localeClassName, "getDisplayVariant", defaultLocale.getDisplayVariant());
+        putState(localeClassName, "getISO3Country", defaultLocale.getISO3Country());
+        putState(localeClassName, "getISO3Language", defaultLocale.getISO3Language());
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            data.add(new Pair<String, Object>("getDisplayScript", defaultLocale.getDisplayScript()));
-            data.add(new Pair<String, Object>("toLanguageTag", defaultLocale.toLanguageTag()));
+            putState(localeClassName, "getDisplayScript", defaultLocale.getDisplayScript());
+            putState(localeClassName, "toLanguageTag", defaultLocale.toLanguageTag());
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            data.add(new Pair<String, Object>("getScript", defaultLocale.getScript()));
+            putState(localeClassName, "getScript", defaultLocale.getScript());
         }
-
-        putAll(Locale.class.getName(), data);
     }
 
-    private void putAll(String fqcn, List<Pair<String, Object>> data) {
-        for (Pair<String, Object> pair : data) {
-            String key = String.format("%s$%s", fqcn, pair.first);
-            try {
-                states.put(key, pair.second);
-            } catch (JSONException e) {
-                Logger.w(e, "Failed to put info: key=%s, value=%s", key, pair.second);
-            }
+    private void putState(String fqcn, String paramName, Object data) {
+        String key = String.format("%s$%s", fqcn, paramName);
+        try {
+            states.put(key, data);
+        } catch (JSONException e) {
+            Logger.w(e, "Failed to put info: key=%s, value=%s", key, data);
         }
-
     }
 }


### PR DESCRIPTION
Collect any device states when creating a capture.
Some attributes are collected on the host app better correctly.
(e.g. per-app language preference: https://developer.android.com/guide/topics/resources/app-languages?hl=ja )