### PR TITLE
Fix: failure to build a sample app with stable flavors

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     devrealImplementation project(':sdk')
     devmockImplementation project(':sdkMock')
 
-    def version = "4.3.0"
+    def version = "4.9.0"
     stablerealImplementation "com.deploygate:sdk:$version"
     stablemockImplementation "com.deploygate:sdk-mock:$version"
 }


### PR DESCRIPTION
Closing #100 

We need to use the latest version SDK when build sample app with `stable` flavors.