### PR TITLE
chore: set some params in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=2g
+kotlin.daemon.jvm.options=-Xmx1536m


### PR DESCRIPTION
Already fixed to avoid causing OOM when upload artifacts for GitHub Actions. #92 
But we encountered again in the other environment.