### PR TITLE
Use the latest SDK version on sample app

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     devrealImplementation project(':sdk')
     devmockImplementation project(':sdkMock')
 
-    def version = "4.9.0"
+    def version = "4.10.0"
     stablerealImplementation "com.deploygate:sdk:$version"
     stablemockImplementation "com.deploygate:sdk-mock:$version"
 }


### PR DESCRIPTION
We published the new SDK version `4.10.0` today.
So we changed to use it when building the sample app.