### PR TITLE
chore(dependabot): set up Dependabot with 3-day cooldown for supply-chain safety

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directories:
+      - "/**"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 3
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,8 @@ version: 2
 updates:
   - package-ecosystem: gradle
     directories:
-      - "/**"
+      - "/"
+      - "/plugins"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
@@ -22,3 +23,4 @@ updates:
     groups:
       actions:
         patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
## 概要
本リポジトリに **Dependabot version updates を新規導入**し、あわせてサプライチェーン攻撃対策として **3日間の cooldown** を設定します。新しく公開された依存バージョンへの更新 PR を 3 日間遅延させ、公開直後の悪意あるバージョンを取り込みにくくします。

## 設定内容
- 対象エコシステム: gradle (/**), github-actions
- スケジュール: weekly
- `cooldown.default-days: 3`（semver 区別なしの一律 3 日）
- ノイズ低減のため minor/patch 更新をグループ化（major は個別 PR）

## 注意
- 本リポジトリでは Dependabot を新規有効化するため、**マージ後に依存更新 PR が新たに発生し始めます**（cooldown により公開から 3 日後）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)